### PR TITLE
Cluster Generator reconciling on cluster secret events

### DIFF
--- a/examples/clusters.yaml
+++ b/examples/clusters.yaml
@@ -10,13 +10,17 @@ metadata:
   name: guestbook
 spec:
   generators:
-  - clusters: {}
+  - clusters:
+      selector:
+        matchLabels:
+          argocd.argoproj.io/secret-type: cluster
   template:
     metadata:
       name: '{{name}}-guestbook'
       labels:
         environment: '{{metadata.labels.environment}}'
     spec:
+      project: ""
       source:
         repoURL: https://github.com/infra-team/cluster-deployments.git
         targetRevision: HEAD

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
+	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect

--- a/pkg/controllers/clustereventhandler.go
+++ b/pkg/controllers/clustereventhandler.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
+	"github.com/argoproj-labs/applicationset/pkg/generators"
+)
+
+// clusterSecretEventHandler is used when watching Secrets to check if they are ArgoCD Cluster Secrets, and if so
+// requeue any related ApplicationSets.
+type clusterSecretEventHandler struct {
+	//handler.EnqueueRequestForOwner
+	Log    log.FieldLogger
+	Client client.Client
+}
+
+func (h *clusterSecretEventHandler) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.queueRelatedAppGenerators(q, e.Meta)
+}
+
+func (h *clusterSecretEventHandler) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.queueRelatedAppGenerators(q, e.MetaNew)
+}
+
+func (h *clusterSecretEventHandler) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.queueRelatedAppGenerators(q, e.Meta)
+}
+
+func (h *clusterSecretEventHandler) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.queueRelatedAppGenerators(q, e.Meta)
+}
+
+func (h *clusterSecretEventHandler) queueRelatedAppGenerators(q workqueue.RateLimitingInterface, meta metav1.Object) {
+	// Check for label, lookup all ApplicationSets that might match the cluster, queue them all
+	if meta.GetLabels()[generators.ArgoCDSecretTypeLabel] != generators.ArgoCDSecretTypeCluster {
+		return
+	}
+
+	h.Log.WithFields(log.Fields{
+		"namespace": meta.GetNamespace(),
+		"name":      meta.GetName(),
+	}).Info("processing event for cluster secret")
+
+	appSetList := &argoprojiov1alpha1.ApplicationSetList{}
+	err := h.Client.List(context.Background(), appSetList)
+	if err != nil {
+		h.Log.WithError(err).Error("unable to list ApplicationSets")
+		return
+	}
+	h.Log.WithField("count", len(appSetList.Items)).Info("listed ApplicationSets")
+	for _, appSet := range appSetList.Items {
+		foundClusterGenerator := false
+		for _, generator := range appSet.Spec.Generators {
+			if generator.Clusters != nil {
+				foundClusterGenerator = true
+				break
+			}
+		}
+		if foundClusterGenerator {
+			// TODO: only queue the AppGenerator if the labels match this cluster
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: appSet.Namespace, Name: appSet.Name}}
+			q.Add(req)
+		}
+	}
+}
+
+

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -1,27 +1,63 @@
 package generators
 
 import (
+	"context"
 	"fmt"
-	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
+)
+
+const (
+	argoCDSecretTypeLabel   = "argocd.argoproj.io/secret-type"
+	argoCDSecretTypeCluster = "cluster"
 )
 
 var _ Generator = (*ClusterGenerator)(nil)
 
 // ClusterGenerator generates Applications for some or all clusters registered with ArgoCD.
 type ClusterGenerator struct {
+	client.Client
 }
 
-func NewClusterGenerator() Generator {
-	// TODO: pass client or informer for access to cluster secrets
-	g := &ClusterGenerator{}
+func NewClusterGenerator(c client.Client) Generator {
+	g := &ClusterGenerator{
+		Client: c,
+	}
 	return g
 }
 
-func (g *ClusterGenerator) GenerateApplications(appSet *argoprojiov1alpha1.ApplicationSetGenerator,
-	appSets *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+func (g *ClusterGenerator) GenerateApplications(
+	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
+	appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+
+	if appSetGenerator == nil {
+		return nil, fmt.Errorf("ApplicationSetGenerator is empty")
+	}
 	if appSet == nil {
 		return nil, fmt.Errorf("ApplicationSet is empty")
+	}
+
+	// List all Clusters:
+	clusterSecretList := &corev1.SecretList{}
+	secretLabels := map[string]string{
+		argoCDSecretTypeLabel: argoCDSecretTypeCluster,
+	}
+	for k, v := range appSetGenerator.Clusters.Selector.MatchLabels {
+		secretLabels[k] = v
+	}
+	if err := g.Client.List(context.Background(), clusterSecretList, client.MatchingLabels(secretLabels)); err != nil {
+		return nil, err
+	}
+	log.Debug("clusters matching labels", "count", len(clusterSecretList.Items))
+
+	for _, cluster := range clusterSecretList.Items {
+		log.WithField("cluster", cluster.Name).Info("matched cluster secret")
 	}
 
 	return nil, nil

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	argoCDSecretTypeLabel   = "argocd.argoproj.io/secret-type"
-	argoCDSecretTypeCluster = "cluster"
+	ArgoCDSecretTypeLabel   = "argocd.argoproj.io/secret-type"
+	ArgoCDSecretTypeCluster = "cluster"
 )
 
 var _ Generator = (*ClusterGenerator)(nil)
@@ -46,7 +46,7 @@ func (g *ClusterGenerator) GenerateApplications(
 	// List all Clusters:
 	clusterSecretList := &corev1.SecretList{}
 	secretLabels := map[string]string{
-		argoCDSecretTypeLabel: argoCDSecretTypeCluster,
+		ArgoCDSecretTypeLabel: ArgoCDSecretTypeCluster,
 	}
 	for k, v := range appSetGenerator.Clusters.Selector.MatchLabels {
 		secretLabels[k] = v

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -16,7 +16,9 @@ func NewGitGenerator() Generator {
 	return g
 }
 
-func (g *GitGenerator) GenerateApplications(appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+func (g *GitGenerator) GenerateApplications(
+	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
+	appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
 	if appSet == nil {
 		return nil, fmt.Errorf("ApplicationSet is empty")
 	}


### PR DESCRIPTION
This PR enables the cluster generator to run and locate all cluster secrets with matching labels. The controller now watches for changes to cluster Secrets and reconciles all appsets with a Cluster generator.