### PR TITLE
fix docker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vendor
 *.swp
 *.swo
 *~
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -o applicationset-controller main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o applicationset-controller main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM debian:10-slim


### PR DESCRIPTION
Docker build was failing with the following error, I removed the go mod and used the same command as the one used in the make file.

Step 4/7 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -o applicationset-controller main.go
 ---> Running in 78592b574262
api/v1alpha1/applicationset_types.go:4:2: cannot find package "." in:
        /workspace/vendor/github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1
pkg/utils/util.go:7:2: cannot find package "." in:
        /workspace/vendor/github.com/pkg/errors
pkg/generators/cluster.go:7:2: cannot find package "." in:
        /workspace/vendor/github.com/sirupsen/logrus
pkg/utils/util.go:8:2: cannot find package "." in:
        /workspace/vendor/github.com/valyala/fasttemplate
pkg/generators/cluster.go:9:2: cannot find package "." in:
        /workspace/vendor/k8s.io/api/core/v1
api/v1alpha1/applicationset_types.go:5:2: cannot find package "." in:
        /workspace/vendor/k8s.io/apimachinery/pkg/apis/meta/v1
api/v1alpha1/zz_generated.deepcopy.go:8:2: cannot find package "." in:
        /workspace/vendor/k8s.io/apimachinery/pkg/runtime
api/v1alpha1/groupversion_info.go:7:2: cannot find package "." in:
        /workspace/vendor/k8s.io/apimachinery/pkg/runtime/schema
pkg/controllers/clustereventhandler.go:9:2: cannot find package "." in:
        /workspace/vendor/k8s.io/apimachinery/pkg/types
main.go:9:2: cannot find package "." in:
        /workspace/vendor/k8s.io/client-go/kubernetes/scheme
main.go:10:2: cannot find package "." in:
        /workspace/vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp
pkg/controllers/applicationset_controller.go:25:2: cannot find package "." in:
        /workspace/vendor/k8s.io/client-go/tools/record
pkg/controllers/clustereventhandler.go:10:2: cannot find package "." in:
        /workspace/vendor/k8s.io/client-go/util/workqueue
pkg/controllers/applicationset_controller.go:26:2: cannot find package "." in:
        /workspace/vendor/k8s.io/kubernetes/pkg/apis/core
pkg/controllers/applicationset_controller.go:33:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime
pkg/generators/cluster.go:10:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/client
pkg/controllers/applicationset_controller.go:27:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
pkg/controllers/clustereventhandler.go:13:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/event
pkg/controllers/applicationset_controller.go:28:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/handler
main.go:12:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/log/zap
api/v1alpha1/groupversion_info.go:8:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/scheme
pkg/controllers/applicationset_controller.go:29:2: cannot find package "." in:
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/source