### PR TITLE
Refactor - Making testing & writing generators more easy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,7 @@ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jW
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/argoproj-labs/applicationset/pkg/generators"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"os"
 
@@ -57,9 +58,12 @@ func main() {
 	}
 
 	if err = (&controllers.ApplicationSetReconciler{
-		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("applicationset-controller"),
+		Generators: []generators.Generator{
+			generators.NewListGenerator(),
+			generators.NewClusterGenerator(mgr.GetClient()),
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ApplicationSet")
 		os.Exit(1)

--- a/pkg/controllers/applicationset_controller.go
+++ b/pkg/controllers/applicationset_controller.go
@@ -62,7 +62,7 @@ func (r *ApplicationSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 
 	// desiredApplications is the main list of all expected Applications from all generators in this appset.
-	desiredApplications := r.extractApplications(applicationSetInfo)
+	desiredApplications := r.generateApplications(applicationSetInfo)
 
 	r.createOrUpdateInCluster(ctx, applicationSetInfo, desiredApplications)
 	r.deleteInCluster(ctx, applicationSetInfo, desiredApplications)
@@ -79,7 +79,7 @@ func getTempApplication(applicationSetTemplate argoprojiov1alpha1.ApplicationSet
 	return &tmplApplication
 }
 
-func (r *ApplicationSetReconciler) extractApplications(applicationSetInfo argoprojiov1alpha1.ApplicationSet) []argov1alpha1.Application {
+func (r *ApplicationSetReconciler) generateApplications(applicationSetInfo argoprojiov1alpha1.ApplicationSet) []argov1alpha1.Application {
 	res := []argov1alpha1.Application{}
 
 	tmplApplication := getTempApplication(applicationSetInfo.Spec.Template)
@@ -102,7 +102,7 @@ func (r *ApplicationSetReconciler) extractApplications(applicationSetInfo argopr
 				res = append(res, *app)
 			}
 
-			log.WithField("generator", g).Infof("generate %d applications", len(res))
+			log.WithField("generator", g).Infof("generated %d applications", len(res))
 			log.WithField("generator", g).Debugf("apps from generator: %+v", res)
 
 		}

--- a/pkg/controllers/applicationset_controller_test.go
+++ b/pkg/controllers/applicationset_controller_test.go
@@ -2,9 +2,12 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/argoproj-labs/applicationset/pkg/generators"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -16,7 +19,149 @@ import (
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 )
 
-func TestCreateOrUpdateApplications(t *testing.T) {
+type generatorMock struct {
+	mock.Mock
+}
+
+func (g *generatorMock) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
+	args := g.Called(appSetGenerator)
+
+	return args.Get(0).([]map[string]string), args.Error(1)
+}
+
+type rendererMock struct {
+	mock.Mock
+}
+
+func (r *rendererMock) RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]string) (*argov1alpha1.Application, error) {
+	args := r.Called(tmpl, params)
+
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*argov1alpha1.Application), args.Error(1)
+
+}
+
+func TestExtractApplications(t *testing.T) {
+	scheme := runtime.NewScheme()
+	argoprojiov1alpha1.AddToScheme(scheme)
+	argov1alpha1.AddToScheme(scheme)
+
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	for _, c := range []struct {
+		name				string
+		params				[]map[string]string
+		template			argoprojiov1alpha1.ApplicationSetTemplate
+		generateParamsError	error
+		rendererError		error
+	}{
+		{
+			name: 		"Generate two applications",
+			params: 	[]map[string]string{{"name": "app1"}, {"name": "app2"}},
+			template:	argoprojiov1alpha1.ApplicationSetTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:                       "name",
+					Namespace:                  "namespace",
+					Labels:                     map[string]string{ "label_name": "label_value"},
+				},
+				Spec:       argov1alpha1.ApplicationSpec{
+
+				},
+			},
+		},
+		{
+			name: 		"Handles error for the generator",
+			generateParamsError: errors.New("error"),
+		},
+		{
+			name: 		"Handles error from the render",
+			params: 	[]map[string]string{{"name": "app1"}, {"name": "app2"}},
+			template:	argoprojiov1alpha1.ApplicationSetTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:                       "name",
+					Namespace:                  "namespace",
+					Labels:                     map[string]string{ "label_name": "label_value"},
+				},
+				Spec:       argov1alpha1.ApplicationSpec{
+
+				},
+			},
+			rendererError: errors.New("error"),
+		},
+	}{
+		cc := c
+		app := argov1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:                       "test",
+			},
+		}
+
+		t.Run(cc.name, func(t *testing.T) {
+
+			generatorMock := generatorMock{}
+			generator := argoprojiov1alpha1.ApplicationSetGenerator{
+				List: &argoprojiov1alpha1.ListGenerator{},
+			}
+
+			generatorMock.On("GenerateParams", &generator).
+				Return(cc.params, cc.generateParamsError)
+
+			rendererMock := rendererMock{}
+
+			expectedApps := []argov1alpha1.Application{}
+
+			if cc.generateParamsError == nil {
+				for _, p := range cc.params {
+
+					if cc.rendererError != nil {
+						rendererMock.On("RenderTemplateParams", getTempApplication(cc.template), p).
+							Return(nil, cc.rendererError)
+					} else{
+						rendererMock.On("RenderTemplateParams", getTempApplication(cc.template), p).
+							Return(&app, nil)
+						expectedApps = append(expectedApps, app)
+					}
+				}
+			}
+
+			r := ApplicationSetReconciler{
+				Client:   client,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(1),
+				Generators: []generators.Generator{
+					&generatorMock,
+				},
+				Renderer: &rendererMock,
+			}
+
+			got := r.extractApplications(argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{generator},
+					Template: cc.template,
+				},
+			},)
+
+			assert.Equal(t, expectedApps, got)
+			generatorMock.AssertNumberOfCalls(t, "GenerateParams", 1)
+
+			if cc.generateParamsError == nil {
+				rendererMock.AssertNumberOfCalls(t, "RenderTemplateParams", len(cc.params))
+			}
+
+		})
+	}
+
+
+}
+
+func TestCreateOrUpdateInCluster(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	argoprojiov1alpha1.AddToScheme(scheme)
@@ -203,7 +348,7 @@ func TestCreateOrUpdateApplications(t *testing.T) {
 
 }
 
-func TestDeleteApplications(t *testing.T) {
+func TestDeleteInCluster(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	argoprojiov1alpha1.AddToScheme(scheme)

--- a/pkg/controllers/applicationset_controller_test.go
+++ b/pkg/controllers/applicationset_controller_test.go
@@ -137,7 +137,7 @@ func TestExtractApplications(t *testing.T) {
 				Renderer: &rendererMock,
 			}
 
-			got := r.extractApplications(argoprojiov1alpha1.ApplicationSet{
+			got := r.generateApplications(argoprojiov1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "namespace",

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -10,8 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
-	"github.com/argoproj-labs/applicationset/pkg/utils"
-	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
 
 const (
@@ -26,6 +24,7 @@ type ClusterGenerator struct {
 	client.Client
 }
 
+
 func NewClusterGenerator(c client.Client) Generator {
 	g := &ClusterGenerator{
 		Client: c,
@@ -33,15 +32,15 @@ func NewClusterGenerator(c client.Client) Generator {
 	return g
 }
 
-func (g *ClusterGenerator) GenerateApplications(
-	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
-	appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+func (g *ClusterGenerator) GenerateParams(
+	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
 
 	if appSetGenerator == nil {
-		return nil, fmt.Errorf("ApplicationSetGenerator is empty")
+		return nil, EmptyAppSetGeneratorError{}
 	}
-	if appSet == nil {
-		return nil, fmt.Errorf("ApplicationSet is empty")
+
+	if appSetGenerator.Clusters == nil {
+		return nil, nil
 	}
 
 	// List all Clusters:
@@ -57,28 +56,18 @@ func (g *ClusterGenerator) GenerateApplications(
 	}
 	log.Debug("clusters matching labels", "count", len(clusterSecretList.Items))
 
-	var tmplApplication argov1alpha1.Application
-	tmplApplication.Namespace = appSet.Spec.Template.Namespace
-	tmplApplication.Name = appSet.Spec.Template.Name
-	tmplApplication.Spec = appSet.Spec.Template.Spec
-
-	var resultingApplications []argov1alpha1.Application
-
-	for _, cluster := range clusterSecretList.Items {
-		params := make(map[string]string)
+	res := make([]map[string]string, len(clusterSecretList.Items))
+	for i, cluster := range clusterSecretList.Items {
+		params := make(map[string]string, len(cluster.ObjectMeta.Labels) + 2)
 		params["name"] = cluster.Name
 		params["server"] = string(cluster.Data["server"])
 		for key, value := range cluster.ObjectMeta.Labels {
 			params[fmt.Sprintf("metadata.labels.%s", key)] = value
 		}
 		log.WithField("cluster", cluster.Name).Info("matched cluster secret")
-		tmpApplication, err := utils.RenderTemplateParams(&tmplApplication, params)
-		if err != nil {
-			log.WithField("cluster", cluster.Name).Error("Error during rendering template params")
-			continue
-		}
-		resultingApplications = append(resultingApplications, *tmpApplication)
+
+		res[i] = params
 	}
 
-	return resultingApplications, nil
+	return res, nil
 }

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -37,7 +37,7 @@ func (g *ClusterGenerator) GenerateParams(
 	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
 
 	if appSetGenerator == nil {
-		return nil, EmptyAppSetGeneratorError{}
+		return nil, EmptyAppSetGeneratorError
 	}
 
 	if appSetGenerator.Clusters == nil {

--- a/pkg/generators/cluster_test.go
+++ b/pkg/generators/cluster_test.go
@@ -2,10 +2,9 @@ package generators
 
 import (
 	"context"
+
 	"encoding/base64"
 	"errors"
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,8 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -30,30 +27,6 @@ func (p *possiblyErroringFakeCtrlRuntimeClient) List(ctx context.Context, secret
 		return errors.New("Could not list Secrets.")
 	}
 	return p.Client.List(ctx, secretList, opts...)
-}
-
-func getRenderTemplate(appName, clusterName, server, environmentLabel string) *argov1alpha1.Application {
-	return &argov1alpha1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", clusterName, appName),
-			Namespace: "namespace",
-			Finalizers: []string{
-				"resources-finalizer.argocd.argoproj.io",
-			},
-		},
-		Spec: argov1alpha1.ApplicationSpec{
-			Source: argov1alpha1.ApplicationSource{
-				RepoURL:        "RepoURL",
-				Path:           fmt.Sprintf("%s/%s", appName, environmentLabel),
-				TargetRevision: "HEAD",
-			},
-			Destination: argov1alpha1.ApplicationDestination{
-				Server:    server,
-				Namespace: "destinationNamespace",
-			},
-			Project: "project",
-		},
-	}
 }
 
 func TestGenerateApplications(t *testing.T) {
@@ -100,57 +73,34 @@ func TestGenerateApplications(t *testing.T) {
 		},
 	}
 
-	applicationSetTemplate := argoprojiov1alpha1.ApplicationSetTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "{{name}}-app",
-			Namespace: "namespace",
-		},
-		Spec: argov1alpha1.ApplicationSpec{
-			Source: argov1alpha1.ApplicationSource{
-				RepoURL:        "RepoURL",
-				Path:           "app/{{metadata.labels.environment}}",
-				TargetRevision: "HEAD",
-			},
-			Destination: argov1alpha1.ApplicationDestination{
-				Server:    "{{server}}",
-				Namespace: "destinationNamespace",
-			},
-			Project: "project",
-		},
-	}
-
 	testCases := []struct {
-		template      argoprojiov1alpha1.ApplicationSetTemplate
 		selector      metav1.LabelSelector
-		expected      []argov1alpha1.Application
+		expected      []map[string]string
 		clientError   bool
 		expectedError error
 	}{
 		{
-			applicationSetTemplate,
 			metav1.LabelSelector{},
-			[]argov1alpha1.Application{
-				*getRenderTemplate("app", "staging-01", "https://staging-01.example.com", "staging"),
-				*getRenderTemplate("app", "production-01", "https://production-01.example.com", "production"),
+			[]map[string]string{
+				{"name": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
+				{"name": "production-01", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
 			},
 			false,
 			nil,
 		},
 		{
-			applicationSetTemplate,
 			metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"environment": "production",
 				},
 			},
-			[]argov1alpha1.Application{
-				*getRenderTemplate("app", "production-01", "https://production-01.example.com", "production"),
+			[]map[string]string{
+				{"name": "production-01", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
 			},
 			false,
 			nil,
 		},
 		{
-			applicationSetTemplate,
 			metav1.LabelSelector{},
 			nil,
 			true,
@@ -166,21 +116,12 @@ func TestGenerateApplications(t *testing.T) {
 		}
 
 		var clusterGenerator = NewClusterGenerator(cl)
-		applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "set",
-			},
-			Spec: argoprojiov1alpha1.ApplicationSetSpec{
-				Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-					Clusters: &argoprojiov1alpha1.ClusterGenerator{
-						Selector: testCase.selector,
-					},
-				}},
-				Template: testCase.template,
-			},
-		}
 
-		got, err := clusterGenerator.GenerateApplications(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo)
+		got, err := clusterGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
+			Clusters: &argoprojiov1alpha1.ClusterGenerator{
+				Selector: testCase.selector,
+			},
+		})
 
 		if testCase.expectedError != nil {
 			assert.Error(t, testCase.expectedError, err)

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -1,9 +1,7 @@
 package generators
 
 import (
-	"fmt"
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
 
 var _ Generator = (*GitGenerator)(nil)
@@ -16,12 +14,6 @@ func NewGitGenerator() Generator {
 	return g
 }
 
-func (g *GitGenerator) GenerateApplications(
-	appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
-	appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
-	if appSet == nil {
-		return nil, fmt.Errorf("ApplicationSet is empty")
-	}
-
+func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
 	return nil, nil
 }

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -24,11 +24,11 @@ func NewGitGenerator(repos services.Apps) Generator {
 func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
 
 	if appSetGenerator == nil {
-		return nil, EmptyAppSetGeneratorError{}
+		return nil, EmptyAppSetGeneratorError
 	}
 
 	if appSetGenerator.Git == nil {
-		return nil, EmptyAppSetGeneratorError{}
+		return nil, EmptyAppSetGeneratorError
 	}
 
 	allApps, err := g.repos.GetApps(context.TODO(), appSetGenerator.Git.RepoURL, appSetGenerator.Git.Revision)

--- a/pkg/generators/interface.go
+++ b/pkg/generators/interface.go
@@ -2,7 +2,6 @@ package generators
 
 import (
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
 
 // Generator defines the interface implemented by all ApplicationSet generators.
@@ -10,6 +9,14 @@ type Generator interface {
 	// GenerateApplications interprets the ApplicationSet and generates all relevant Applications.
 	// The expected / desired list of Applications is returned, it then needs to be reconciled
 	// against the current state of the Applications in the cluster.
-	GenerateApplications(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
-		appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error)
+	GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error)
 }
+
+type EmptyAppSetGeneratorError struct {
+
+}
+
+func (e EmptyAppSetGeneratorError) Error() string{
+	return "ApplicationSet is empty"
+}
+

--- a/pkg/generators/interface.go
+++ b/pkg/generators/interface.go
@@ -1,22 +1,18 @@
 package generators
 
 import (
+	"errors"
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 )
 
 // Generator defines the interface implemented by all ApplicationSet generators.
 type Generator interface {
-	// GenerateApplications interprets the ApplicationSet and generates all relevant Applications.
-	// The expected / desired list of Applications is returned, it then needs to be reconciled
+	// GenerateParams interprets the ApplicationSet and generates all relevant parameters for the application template.
+	// This function will be called for every generator,
+	//even if there isn't any application - in this case the result should be nil without an error
+	// The expected / desired list of parameters is returned, it then needs to be render and reconciled
 	// against the current state of the Applications in the cluster.
 	GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error)
 }
 
-type EmptyAppSetGeneratorError struct {
-
-}
-
-func (e EmptyAppSetGeneratorError) Error() string{
-	return "ApplicationSet is empty"
-}
-
+var EmptyAppSetGeneratorError = errors.New("ApplicationSet is empty")

--- a/pkg/generators/list.go
+++ b/pkg/generators/list.go
@@ -18,7 +18,7 @@ func NewListGenerator() Generator {
 
 func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
 	if appSetGenerator == nil {
-		return nil, EmptyAppSetGeneratorError{}
+		return nil, EmptyAppSetGeneratorError
 	}
 
 	if appSetGenerator.List == nil {

--- a/pkg/generators/list.go
+++ b/pkg/generators/list.go
@@ -1,16 +1,14 @@
 package generators
 
 import (
-	"fmt"
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 	"github.com/argoproj-labs/applicationset/pkg/utils"
-	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	log "github.com/sirupsen/logrus"
 )
 
 var _ Generator = (*ListGenerator)(nil)
 
 type ListGenerator struct {
+
 }
 
 func NewListGenerator() Generator {
@@ -18,34 +16,21 @@ func NewListGenerator() Generator {
 	return g
 }
 
-func (g *ListGenerator) GenerateApplications(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator,
-	appSet *argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
-	if appSetGenerator == nil || appSet == nil {
-		return nil, fmt.Errorf("ApplicationSet is empty")
+func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
+	if appSetGenerator == nil {
+		return nil, EmptyAppSetGeneratorError{}
 	}
 
 	if appSetGenerator.List == nil {
 		return nil, nil
 	}
 
-	listGenerator := appSetGenerator.List
-
-	if listGenerator == nil {
-		return nil, fmt.Errorf("Empty list generator ")
-	}
-
-	var tmplApplication argov1alpha1.Application
-	tmplApplication.Namespace = appSet.Spec.Template.Namespace
-	tmplApplication.Name = appSet.Spec.Template.Name
-	tmplApplication.Spec = appSet.Spec.Template.Spec
-
-	params := make(map[string]string, 2)
-	for _, tmpItem := range listGenerator.Elements {
+	res := make([]map[string]string, len(appSetGenerator.List.Elements))
+	for _, tmpItem := range appSetGenerator.List.Elements {
+		params := make(map[string]string, 2)
 		params[utils.ClusterListGeneratorKeyName] = tmpItem.Cluster
 		params[utils.UrlGeneratorKeyName] = tmpItem.Url
-		tmpApplication, err := utils.RenderTemplateParams(&tmplApplication, params)
-		log.Debugf("tmpApplication %++v", tmpApplication)
-		log.Debugf("error %v", err)
+		res = append(res, params)
 	}
-	return nil, nil
+	return res, nil
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -25,7 +25,7 @@ func RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]stri
 	}
 
 	fstTmpl := fasttemplate.New(string(tmplBytes), "{{", "}}")
-	replacedTmplStr, err := Replace(fstTmpl, params, true)
+	replacedTmplStr, err := replace(fstTmpl, params, true)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]stri
 // allowUnresolved indicates whether or not it is acceptable to have unresolved variables
 // remaining in the substituted template. prefixFilter will apply the replacements only
 // to variables with the specified prefix
-func Replace(fstTmpl *fasttemplate.Template, replaceMap map[string]string, allowUnresolved bool) (string, error) {
+func replace(fstTmpl *fasttemplate.Template, replaceMap map[string]string, allowUnresolved bool) (string, error) {
 	var unresolvedErr error
 	replacedTmpl := fstTmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
 		replacement, ok := replaceMap[tag]

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -10,7 +10,15 @@ import (
 	"strconv"
 )
 
-func RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]string) (*argov1alpha1.Application, error) {
+type Renderer interface {
+	RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]string) (*argov1alpha1.Application, error)
+}
+
+type Render struct {
+
+}
+
+func (r *Render) RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]string) (*argov1alpha1.Application, error) {
 	if tmpl == nil {
 		return nil, fmt.Errorf("Application template is empty ")
 	}
@@ -25,7 +33,7 @@ func RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]stri
 	}
 
 	fstTmpl := fasttemplate.New(string(tmplBytes), "{{", "}}")
-	replacedTmplStr, err := replace(fstTmpl, params, true)
+	replacedTmplStr, err := r.replace(fstTmpl, params, true)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +56,7 @@ func RenderTemplateParams(tmpl *argov1alpha1.Application, params map[string]stri
 // allowUnresolved indicates whether or not it is acceptable to have unresolved variables
 // remaining in the substituted template. prefixFilter will apply the replacements only
 // to variables with the specified prefix
-func replace(fstTmpl *fasttemplate.Template, replaceMap map[string]string, allowUnresolved bool) (string, error) {
+func (r *Render) replace(fstTmpl *fasttemplate.Template, replaceMap map[string]string, allowUnresolved bool) (string, error) {
 	var unresolvedErr error
 	replacedTmpl := fstTmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
 		replacement, ok := replaceMap[tag]


### PR DESCRIPTION
1. Extract common parts from the generators. Now a generator only creates the params for the application, and the rendering is happing outside.
Generator now has only one unique responsibility.

2. Refactor the if-else generator chooser to a simpler loop, and move the generators list to outside the function.
Making the code more clean, easy to test, and easy to add a new generator

This PR is going to brake every PR, so it will be better to merge: #25 , #24 , #21 before this one