### PR TITLE
Improve and document the developer deployment process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ compatibility are made, at least until merging into Argo CD proper.
 ## Proposal:
 * https://docs.google.com/document/d/1juWGr20FQaJmuuTIS8mBFmWWDU422M_FQMuhp5c1jt4/edit?usp=sharing
 
+## Development Instructions
+
+The following assumes you have: 
+
+ 1. Installed a recent version of [kustomize](https://github.com/kubernetes-sigs/kustomize) (3.x+). 
+ 1. Created a container repository for your development image.
+ 1. Deployed ArgoCD into the "argocd" namespace.
+ 
+To build and push a container with your current code, and deploy Kubernetes manifests for the controller Deployment:
+
+```bash
+IMAGE="username/argocd-applicationset:v0.0.1" make image deploy
+```
+
+The ApplicationSet controller should now be running in the "argocd" namespace.
+
 ## Example Spec:
 
 ```yaml
@@ -40,3 +56,4 @@ spec:
 ```
 
 Additional examples are available in the [examples](./examples) directory.
+


### PR DESCRIPTION
Rather than require developers to change on disk files in the git index,
or create custom patching solutions, introduce a make target that allows
us to build, push, and deploy manifests in a single command.

Adds namespace to the ServiceAccount subject in the ClusterRoleBinding,
as far as I can tell this was invalid yaml.