### PR TITLE
Fix rbac error listing Secrets at cluster scope.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +21,10 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+)
+
+const (
+	defaultNamespace = "argocd"
 )
 
 func init() {
@@ -43,9 +49,23 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	// Determine the namespace we're running in. Normally injected into the pod as an env
+	// var via the Kube downward API configured in the Deployment. We also default to "argocd"
+	// for developers running the binary locally who may not remember to set a NAMESPACE environment
+	// variable.
+	ns := os.Getenv("NAMESPACE")
+	if len(ns) == 0 {
+		ns = defaultNamespace
+	}
+	setupLog.Info("using argocd namespace", "namespace", ns)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
+		// Our cache and thus watches and client queries are restricted to the namespace we're running in. This assumes
+		// the applicationset controller is in the same namespace as argocd, which should be the same namespace of
+		// all cluster Secrets and Applications we interact with.
+		NewCache: cache.MultiNamespacedCacheBuilder([]string{ns}),
 		HealthProbeBindAddress: probeBindAddr,
 		Port:                   9443,
 		LeaderElection:         enableLeaderElection,

--- a/main.go
+++ b/main.go
@@ -23,10 +23,6 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-const (
-	defaultNamespace = "argocd"
-)
-
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
@@ -50,12 +46,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// Determine the namespace we're running in. Normally injected into the pod as an env
-	// var via the Kube downward API configured in the Deployment. We also default to "argocd"
-	// for developers running the binary locally who may not remember to set a NAMESPACE environment
-	// variable.
+	// var via the Kube downward API configured in the Deployment.
+	// Developers running the binary locally will need to remember to set the NAMESPACE environment variable.
 	ns := os.Getenv("NAMESPACE")
 	if len(ns) == 0 {
-		ns = defaultNamespace
+		setupLog.Info("Please set NAMESPACE environment variable to match where you are running the applicationset controller")
+		os.Exit(1)
 	}
 	setupLog.Info("using argocd namespace", "namespace", ns)
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -21,4 +21,9 @@ spec:
           image: registry.cn-hangzhou.aliyuncs.com/appcenter/argocd-applicationset:v0.1.0
           imagePullPolicy: Always
           name: argocd-applicationset-controller
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       serviceAccountName: argocd-applicationset-controller


### PR DESCRIPTION
The Secret Watch established in the ApplicationSet controller is global,
and rbac for global secrets was recently removed resulting in a broken
controller.

To work past this and avoid re-introducing global Secret watch RBAC, the
Manager's cache is now limited to only the namespace in which it is
running. This implies that any attempts to use the client outside that
namespace will not work. However this should be safe as we work with
Applications and Secrets, both of which should not exist beyond the
ArgoCD namespace where we're running.