### PR TITLE
Use cluster name for generator param.

### DIFF
--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -66,7 +66,7 @@ func (g *ClusterGenerator) GenerateApplications(
 
 	for _, cluster := range clusterSecretList.Items {
 		params := make(map[string]string)
-		params["name"] = cluster.Name
+		params["name"] = string(cluster.Data["name"])
 		params["server"] = string(cluster.Data["server"])
 		for key, value := range cluster.ObjectMeta.Labels {
 			params[fmt.Sprintf("metadata.labels.%s", key)] = value


### PR DESCRIPTION
The secret name is quite long and an implementation detail. The actual
name as far as argocd is linked to the kubeconfig context name and quite
likely shorter.