### PR TITLE
chore(kustomize): set default namespace to argocd

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
   - deployment.yaml
   - rbac.yaml

--- a/manifests/cluster-install/kustomization.yaml
+++ b/manifests/cluster-install/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
   - ../namespace-install
   - ../cluster-rbac

--- a/manifests/cluster-rbac/kustomization.yaml
+++ b/manifests/cluster-rbac/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
   - rbac.yaml

--- a/manifests/namespace-install/kustomization.yaml
+++ b/manifests/namespace-install/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
   - ../base
   - ../crds


### PR DESCRIPTION
Sets the default kustomize installation namespace to `argocd`. This can be overridden by end-users in their own overlays:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: foo

resources:
  - github.com/argoproj-labs/applicationset/manifests/cluster-install
```

Signed-off-by: Michael Goodness <michael.goodness@mlb.com>