### PR TITLE
add sync status

### DIFF
--- a/pkg/controllers/applicationset_controller_test.go
+++ b/pkg/controllers/applicationset_controller_test.go
@@ -356,6 +356,193 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 
 }
 
+func TestCreateApplications(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	argoprojiov1alpha1.AddToScheme(scheme)
+	argov1alpha1.AddToScheme(scheme)
+
+	for _, c := range []struct {
+		appSet     argoprojiov1alpha1.ApplicationSet
+		existsApps []argov1alpha1.Application
+		apps       []argov1alpha1.Application
+		expected   []argov1alpha1.Application
+	}{
+		{
+			appSet: argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			},
+			existsApps: nil,
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app1",
+					},
+				},
+			},
+			expected: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Application",
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "1",
+					},
+				},
+			},
+		},
+		{
+			appSet: argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					Template: argoprojiov1alpha1.ApplicationSetTemplate{
+						Spec: argov1alpha1.ApplicationSpec{
+							Project: "project",
+						},
+					},
+				},
+			},
+			existsApps: []argov1alpha1.Application{
+				argov1alpha1.Application{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Application",
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "2",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "test",
+					},
+				},
+			},
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app1",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
+			expected: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Application",
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "2",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "test",
+					},
+				},
+			},
+		},
+		{
+			appSet: argoprojiov1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+					Template: argoprojiov1alpha1.ApplicationSetTemplate{
+						Spec: argov1alpha1.ApplicationSpec{
+							Project: "project",
+						},
+					},
+				},
+			},
+			existsApps: []argov1alpha1.Application{
+				argov1alpha1.Application{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Application",
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "2",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "test",
+					},
+				},
+			},
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app2",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
+			expected: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Application",
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app2",
+						Namespace:       "namespace",
+						ResourceVersion: "1",
+					},
+					Spec: argov1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
+		},
+	} {
+		initObjs := []runtime.Object{&c.appSet}
+		for _, a := range c.existsApps {
+			controllerutil.SetControllerReference(&c.appSet, &a, scheme)
+			initObjs = append(initObjs, &a)
+		}
+
+		client := fake.NewFakeClientWithScheme(scheme, initObjs...)
+
+		r := ApplicationSetReconciler{
+			Client:   client,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(len(initObjs) + len(c.expected)),
+		}
+
+		r.createInCluster(context.TODO(), c.appSet, c.apps)
+
+		for _, obj := range c.expected {
+			got := &argov1alpha1.Application{}
+			_ = client.Get(context.Background(), crtclient.ObjectKey{
+				Namespace: obj.Namespace,
+				Name:      obj.Name,
+			}, got)
+
+			controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+
+			assert.Equal(t, obj, *got)
+		}
+	}
+
+}
+
 func TestDeleteInCluster(t *testing.T) {
 
 	scheme := runtime.NewScheme()

--- a/pkg/utils/policy.go
+++ b/pkg/utils/policy.go
@@ -1,0 +1,45 @@
+package utils
+
+// Policy allows to apply different rules to a set of changes.
+type Policy interface {
+	Update() bool
+	Delete() bool
+}
+
+// Policies is a registry of available policies.
+var Policies = map[string]Policy{
+	"sync":        &SyncPolicy{},
+	"create-only": &CreateOnlyPolicy{},
+	"create-update": &CreateUpdatePolicy{},
+}
+
+type SyncPolicy struct{}
+
+func (p *SyncPolicy) Update() bool {
+	return true
+}
+
+func (p *SyncPolicy) Delete() bool {
+	return true
+}
+
+type CreateUpdatePolicy struct{}
+
+func (p *CreateUpdatePolicy) Update() bool {
+	return true
+}
+
+func (p *CreateUpdatePolicy) Delete() bool {
+	return false
+}
+
+type CreateOnlyPolicy struct{}
+
+func (p *CreateOnlyPolicy) Update() bool {
+	return false
+}
+
+func (p *CreateOnlyPolicy) Delete() bool {
+	return false
+}
+


### PR DESCRIPTION
Add the option to determine the sync status. When using the git generator, a  user can cause an application to be deleted by changing the name of the folder. This PR aimed to give an option to prevent delete / update in the reconcile. 

It's should probably be part of the generator metadata, but for now, we can start with a global flag.

Based on the policies from external-dns