### PR TITLE
add requeueAfter option

### DIFF
--- a/api/v1alpha1/applicationset_types.go
+++ b/api/v1alpha1/applicationset_types.go
@@ -70,9 +70,10 @@ type ClusterGenerator struct {
 }
 
 type GitGenerator struct {
-	RepoURL     string                      `json:"repoURL"`
-	Directories []GitDirectoryGeneratorItem `json:"directories,omitempty"`
-	Revision    string                      `json:"revision"`
+	RepoURL     		string                      `json:"repoURL"`
+	Directories 		[]GitDirectoryGeneratorItem `json:"directories,omitempty"`
+	Revision    		string                      `json:"revision"`
+	RequeueAfterSeconds	int64						`json:"requeueAfterSeconds,omitempty"`
 }
 
 type GitDirectoryGeneratorItem struct {

--- a/examples/list.yaml
+++ b/examples/list.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: guestbook2
+  name: guestbook
 spec:
   generators:
   - list:
@@ -12,10 +12,10 @@ spec:
       - cluster: engineering-prod
         url: https://2.4.6.8
       - cluster: finance-preprod
-        url: https://9.8.7.10
+        url: https://9.8.7.6
   template:
     metadata:
-      name: '{{cluster}}-guestbook2'
+      name: '{{cluster}}-guestbook'
     spec:
       project: ""
       source:

--- a/examples/list.yaml
+++ b/examples/list.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: guestbook
+  name: guestbook2
 spec:
   generators:
   - list:
@@ -12,10 +12,10 @@ spec:
       - cluster: engineering-prod
         url: https://2.4.6.8
       - cluster: finance-preprod
-        url: https://9.8.7.6
+        url: https://9.8.7.10
   template:
     metadata:
-      name: '{{cluster}}-guestbook'
+      name: '{{cluster}}-guestbook2'
     spec:
       project: ""
       source:

--- a/main.go
+++ b/main.go
@@ -101,10 +101,10 @@ func main() {
 	k8s := kubernetes.NewForConfigOrDie(mgr.GetConfig())
 
 	if err = (&controllers.ApplicationSetReconciler{
-		Generators: []generators.Generator{
-			generators.NewListGenerator(),
-			generators.NewClusterGenerator(mgr.GetClient()),
-			generators.NewGitGenerator(services.NewArgoCDService(context.Background(), k8s, namespace, argocdRepoServer)),
+		Generators: map[string]generators.Generator{
+			"List": generators.NewListGenerator(),
+			"Clusters": generators.NewClusterGenerator(mgr.GetClient()),
+			"Git": generators.NewGitGenerator(services.NewArgoCDService(context.Background(), k8s, namespace, argocdRepoServer)),
 		},
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -118,6 +118,9 @@ spec:
                         type: string
                       revision:
                         type: string
+                      requeueAfterSeconds:
+                        format: int64
+                        type: integer
                     required:
                     - repoURL
                     - revision

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"context"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -31,6 +32,10 @@ func NewClusterGenerator(c client.Client) Generator {
 		Client: c,
 	}
 	return g
+}
+
+func (g * ClusterGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration {
+	return NoRequeueAfter
 }
 
 func (g *ClusterGenerator) GenerateParams(

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -6,6 +6,7 @@ import (
 	"github.com/argoproj-labs/applicationset/pkg/services"
 	log "github.com/sirupsen/logrus"
 	"path"
+	"time"
 )
 
 var _ Generator = (*GitGenerator)(nil)
@@ -19,6 +20,10 @@ func NewGitGenerator(repos services.Apps) Generator {
 		repos: repos,
 	}
 	return g
+}
+
+func (g * GitGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration {
+	return time.Duration(appSetGenerator.Git.RequeueAfterSeconds) * time.Second
 }
 
 func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {

--- a/pkg/generators/interface.go
+++ b/pkg/generators/interface.go
@@ -3,16 +3,23 @@ package generators
 import (
 	"errors"
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
+	"time"
 )
+
+
 
 // Generator defines the interface implemented by all ApplicationSet generators.
 type Generator interface {
 	// GenerateParams interprets the ApplicationSet and generates all relevant parameters for the application template.
-	// This function will be called for every generator,
-	//even if there isn't any application - in this case the result should be nil without an error
-	// The expected / desired list of parameters is returned, it then needs to be render and reconciled
+	// The expected / desired list of parameters is returned, it then will be render and reconciled
 	// against the current state of the Applications in the cluster.
 	GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error)
+
+	// GetRequeueAfter is the the generator can controller the next reconciled loop
+	// In case there is more then one generator the time will be the minimum of the times.
+	// In case NoRequeueAfter is empty, it will be ignored
+	GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration
 }
 
 var EmptyAppSetGeneratorError = errors.New("ApplicationSet is empty")
+var NoRequeueAfter time.Duration

--- a/pkg/generators/list.go
+++ b/pkg/generators/list.go
@@ -3,6 +3,7 @@ package generators
 import (
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 	"github.com/argoproj-labs/applicationset/pkg/utils"
+	"time"
 )
 
 var _ Generator = (*ListGenerator)(nil)
@@ -14,6 +15,10 @@ type ListGenerator struct {
 func NewListGenerator() Generator {
 	g := &ListGenerator{}
 	return g
+}
+
+func (g * ListGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration {
+	return NoRequeueAfter
 }
 
 func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {


### PR DESCRIPTION
In the git generator, there is a need for a mechanism to get updates from the git repo. This PR adds the option to set a timer for reconciling the generator. 

If there is more then one generator at different times, the minimum time will be taken.