### PR TITLE
Fix make deploy step

### DIFF
--- a/manifests/crds/kustomization.yaml
+++ b/manifests/crds/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - applicationset-crd.yaml
+  - argoproj.io_applicationsets.yaml


### PR DESCRIPTION
Fix the following error
```
❯ make deploy
kustomize build manifests/namespace-install | kubectl apply -f -
Error: accumulating resources: 2 errors occurred:
	* accumulateFile error: "accumulating resources from '../crds': '~/git/third-party/applicationset/manifests/crds' must resolve to a file"
	* accumulateDirector error: "recursed accumulation of path '~/git/third-party/applicationset/manifests/crds': accumulating resources: 2 errors occurred:\n\t* accumulateFile error: \"accumulating resources from 'applicationset-crd.yaml': evalsymlink failure on '~/git/third-party/applicationset/manifests/crds/applicationset-crd.yaml' : lstat ~/git/third-party/applicationset/manifests/crds/applicationset-crd.yaml: no such file or directory\"\n\t* loader.New error: \"error loading applicationset-crd.yaml with git: url lacks orgRepo: applicationset-crd.yaml, dir: evalsymlink failure on '~/git/third-party/applicationset/manifests/crds/applicationset-crd.yaml' : lstat ~/git/third-party/applicationset/manifests/crds/applicationset-crd.yaml: no such file or directory, get: invalid source string: applicationset-crd.yaml\"\n\n"


error: no objects passed to apply
make: *** [deploy] Error 1
```
because the CRD generated with `make manifests` is called `argoproj.io_applicationsets.yaml`.