### PR TITLE
Add .golangci.yml from Argo CD, and fix corresponding linter failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+run:
+  timeout: 2m
+  skip-files:
+  skip-dirs:
+linters:
+  enable:
+    - vet
+    - deadcode
+    - goimports
+    - varcheck
+    - structcheck
+    - ineffassign
+    - unconvert
+    - unparam

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ DOCKER_PUSH?=true
 build:
 	CGO_ENABLED=0 go build -ldflags="-w -s" -o ./dist/argocd-applicationset .
 
+.PHONY: test
+test:
+	go test -race -count=1 `go list ./...`
+
 .PHONY: image
 image:
 	docker build -t $(IMAGE) .
@@ -21,6 +25,11 @@ deploy:
 manifests:
 	controller-gen paths=./api/... crd:trivialVersions=true output:dir=./manifests/crds/
 	controller-gen object paths=./api/...
+
+lint:
+	golangci-lint --version
+	GOMAXPROCS=2 golangci-lint run --fix --verbose --timeout 300s
+
 
 # Run go fmt against code
 fmt:

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+
 	"github.com/argoproj-labs/applicationset/pkg/generators"
 	"github.com/argoproj-labs/applicationset/pkg/services"
 	"github.com/argoproj-labs/applicationset/pkg/utils"

--- a/pkg/controllers/applicationset_controller.go
+++ b/pkg/controllers/applicationset_controller.go
@@ -280,7 +280,8 @@ func (r *ApplicationSetReconciler) createInCluster(ctx context.Context, applicat
 	return r.createOrUpdateInCluster(ctx, applicationSet, createApps)
 }
 
-func (r *ApplicationSetReconciler) getCurrentApplications(ctx context.Context, applicationSet argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+func (r *ApplicationSetReconciler) getCurrentApplications(_ context.Context, applicationSet argoprojiov1alpha1.ApplicationSet) ([]argov1alpha1.Application, error) {
+	// TODO: Should this use the context param?
 	var current argov1alpha1.ApplicationList
 	err := r.Client.List(context.Background(), &current, client.MatchingFields{".metadata.controller": applicationSet.Name})
 
@@ -313,7 +314,7 @@ func (r *ApplicationSetReconciler) deleteInCluster(ctx context.Context, applicat
 		appLog := log.WithFields(log.Fields{"app": app.Name, "appSet": applicationSet.Name})
 		_, exists := m[app.Name]
 
-		if exists == false {
+		if !exists {
 			err := r.Client.Delete(ctx, &app)
 			if err != nil {
 				appLog.WithError(err).Error("failed to delete Application")

--- a/pkg/controllers/applicationset_controller_test.go
+++ b/pkg/controllers/applicationset_controller_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/argoproj-labs/applicationset/pkg/generators"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +17,6 @@ import (
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"testing"
-	"time"
 
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 )
@@ -53,8 +54,11 @@ func (r *rendererMock) RenderTemplateParams(tmpl *argov1alpha1.Application, para
 
 func TestExtractApplications(t *testing.T) {
 	scheme := runtime.NewScheme()
-	argoprojiov1alpha1.AddToScheme(scheme)
-	argov1alpha1.AddToScheme(scheme)
+	err := argoprojiov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
+
+	err = argov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
 
 	client := fake.NewFakeClientWithScheme(scheme)
 
@@ -174,8 +178,11 @@ func TestExtractApplications(t *testing.T) {
 func TestCreateOrUpdateInCluster(t *testing.T) {
 
 	scheme := runtime.NewScheme()
-	argoprojiov1alpha1.AddToScheme(scheme)
-	argov1alpha1.AddToScheme(scheme)
+	err := argoprojiov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
+
+	err = argov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
 
 	for _, c := range []struct {
 		appSet     argoprojiov1alpha1.ApplicationSet
@@ -329,7 +336,8 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 	} {
 		initObjs := []runtime.Object{&c.appSet}
 		for _, a := range c.existsApps {
-			controllerutil.SetControllerReference(&c.appSet, &a, scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &a, scheme)
+			assert.Nil(t, err)
 			initObjs = append(initObjs, &a)
 		}
 
@@ -341,7 +349,8 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 			Recorder: record.NewFakeRecorder(len(initObjs) + len(c.expected)),
 		}
 
-		r.createOrUpdateInCluster(context.TODO(), c.appSet, c.apps)
+		err = r.createOrUpdateInCluster(context.TODO(), c.appSet, c.apps)
+		assert.Nil(t, err)
 
 		for _, obj := range c.expected {
 			got := &argov1alpha1.Application{}
@@ -350,7 +359,8 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 				Name:      obj.Name,
 			}, got)
 
-			controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			assert.Nil(t, err)
 
 			assert.Equal(t, obj, *got)
 		}
@@ -361,8 +371,11 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 func TestCreateApplications(t *testing.T) {
 
 	scheme := runtime.NewScheme()
-	argoprojiov1alpha1.AddToScheme(scheme)
-	argov1alpha1.AddToScheme(scheme)
+	err := argoprojiov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
+
+	err = argov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
 
 	for _, c := range []struct {
 		appSet     argoprojiov1alpha1.ApplicationSet
@@ -516,7 +529,8 @@ func TestCreateApplications(t *testing.T) {
 	} {
 		initObjs := []runtime.Object{&c.appSet}
 		for _, a := range c.existsApps {
-			controllerutil.SetControllerReference(&c.appSet, &a, scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &a, scheme)
+			assert.Nil(t, err)
 			initObjs = append(initObjs, &a)
 		}
 
@@ -528,7 +542,8 @@ func TestCreateApplications(t *testing.T) {
 			Recorder: record.NewFakeRecorder(len(initObjs) + len(c.expected)),
 		}
 
-		r.createInCluster(context.TODO(), c.appSet, c.apps)
+		err = r.createInCluster(context.TODO(), c.appSet, c.apps)
+		assert.Nil(t, err)
 
 		for _, obj := range c.expected {
 			got := &argov1alpha1.Application{}
@@ -537,7 +552,8 @@ func TestCreateApplications(t *testing.T) {
 				Name:      obj.Name,
 			}, got)
 
-			controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			assert.Nil(t, err)
 
 			assert.Equal(t, obj, *got)
 		}
@@ -548,8 +564,10 @@ func TestCreateApplications(t *testing.T) {
 func TestDeleteInCluster(t *testing.T) {
 
 	scheme := runtime.NewScheme()
-	argoprojiov1alpha1.AddToScheme(scheme)
-	argov1alpha1.AddToScheme(scheme)
+	err := argoprojiov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
+	err = argov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
 
 	for _, c := range []struct {
 		appSet      argoprojiov1alpha1.ApplicationSet
@@ -649,7 +667,8 @@ func TestDeleteInCluster(t *testing.T) {
 		initObjs := []runtime.Object{&c.appSet}
 		for _, a := range c.existsApps {
 			temp := a
-			controllerutil.SetControllerReference(&c.appSet, &temp, scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &temp, scheme)
+			assert.Nil(t, err)
 			initObjs = append(initObjs, &temp)
 		}
 
@@ -661,7 +680,8 @@ func TestDeleteInCluster(t *testing.T) {
 			Recorder: record.NewFakeRecorder(len(initObjs) + len(c.expected)),
 		}
 
-		r.deleteInCluster(context.TODO(), c.appSet, c.apps)
+		err = r.deleteInCluster(context.TODO(), c.appSet, c.apps)
+		assert.Nil(t, err)
 
 		for _, obj := range c.expected {
 			got := &argov1alpha1.Application{}
@@ -670,7 +690,8 @@ func TestDeleteInCluster(t *testing.T) {
 				Name:      obj.Name,
 			}, got)
 
-			controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			err = controllerutil.SetControllerReference(&c.appSet, &obj, r.Scheme)
+			assert.Nil(t, err)
 
 			assert.Equal(t, obj, *got)
 		}
@@ -689,8 +710,10 @@ func TestDeleteInCluster(t *testing.T) {
 
 func TestGetMinRequeueAfter(t *testing.T) {
 	scheme := runtime.NewScheme()
-	argoprojiov1alpha1.AddToScheme(scheme)
-	argov1alpha1.AddToScheme(scheme)
+	err := argoprojiov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
+	err = argov1alpha1.AddToScheme(scheme)
+	assert.Nil(t, err)
 
 	client := fake.NewFakeClientWithScheme(scheme)
 

--- a/pkg/generators/cluster.go
+++ b/pkg/generators/cluster.go
@@ -57,7 +57,7 @@ func (g *ClusterGenerator) GenerateParams(
 		return nil, err
 	}
 
-	if err := g.Client.List(context.Background(), clusterSecretList, client.MatchingLabelsSelector{secretSelector}); err != nil {
+	if err := g.Client.List(context.Background(), clusterSecretList, client.MatchingLabelsSelector{Selector: secretSelector}); err != nil {
 		return nil, err
 	}
 	log.Debug("clusters matching labels", "count", len(clusterSecretList.Items))

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -74,7 +74,8 @@ func (g *GitGenerator) filter(Directories []argoprojiov1alpha1.GitDirectoryGener
 	return res
 }
 
-func (g *GitGenerator) generateParams(requestedApps []string, appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) []map[string]string {
+func (g *GitGenerator) generateParams(requestedApps []string, _ *argoprojiov1alpha1.ApplicationSetGenerator) []map[string]string {
+	// TODO: At some point, the appicationSetGenerator param should be used
 
 	res := make([]map[string]string, len(requestedApps))
 	for i, a := range requestedApps {

--- a/pkg/generators/interface.go
+++ b/pkg/generators/interface.go
@@ -2,8 +2,9 @@ package generators
 
 import (
 	"errors"
-	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 	"time"
+
+	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 )
 
 // Generator defines the interface implemented by all ApplicationSet generators.

--- a/pkg/generators/list.go
+++ b/pkg/generators/list.go
@@ -1,9 +1,10 @@
 package generators
 
 import (
+	"time"
+
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
 	"github.com/argoproj-labs/applicationset/pkg/utils"
-	"time"
 )
 
 var _ Generator = (*ListGenerator)(nil)

--- a/pkg/services/repo_service.go
+++ b/pkg/services/repo_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/util/db"
@@ -60,7 +61,7 @@ func (a *argoCDService) GetApps(ctx context.Context, repoURL string, revision st
 
 	res := []string{}
 
-	for name, _ := range apps.Apps {
+	for name := range apps.Apps {
 		res = append(res, name)
 	}
 

--- a/pkg/utils/createOrUpdate.go
+++ b/pkg/utils/createOrUpdate.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -3,11 +3,12 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
+
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasttemplate"
-	"io"
-	"strconv"
 )
 
 type Renderer interface {


### PR DESCRIPTION
I've added the `.golangci.yml` from Argo CD, with the same enabled linters that it uses, and then fixed all the failing lines. 