### PR TITLE
Add build and test GH action, fix TestGetApps race condition (#83)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Restore go build cache
         uses: actions/cache@v1
         with:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Install required packages
         run: |
           sudo apt-get install git -y

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,98 @@
+name: Integration tests
+on: 
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+
+  build-docker:
+    name: Ensure Docker image builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build Docker image
+        run: |
+          DOCKER_PUSH=false make image
+
+  build-go:
+    name: Build & cache Go code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+      - name: Download all Go modules
+        run: |
+          go mod download
+      - name: Compile all packages
+        run: make build
+
+  test-go:
+    name: Run unit tests for Go packages
+    runs-on: ubuntu-latest
+    needs:
+      - build-go
+    steps:
+      - name: Create checkout directory
+        run: mkdir -p ~/go/src/github.com/argoproj-labs
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create symlink in GOPATH
+        run: ln -s $(pwd) ~/go/src/github.com/argoproj-labs
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Install required packages
+        run: |
+          sudo apt-get install git -y
+      - name: Switch to temporal branch so we re-attach head
+        run: |
+          git switch -c temporal-pr-branch
+          git status
+      - name: Fetch complete history for blame information
+        run: |
+          git fetch --prune --no-tags --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+      - name: Add ~/go/bin to PATH
+        run: |
+          echo "/home/runner/go/bin" >> $GITHUB_PATH
+      - name: Add /usr/local/bin to PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+      - name: Setup git username and email
+        run: |
+          git config --global user.name "John Doe"
+          git config --global user.email "john.doe@example.com"
+      - name: Download and vendor all required packages
+        run: |
+          go mod download
+      - name: Run all unit tests
+        run: make test
+      - name: Generate code coverage artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage
+          path: coverage.out
+      - name: Generate test results artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 .PHONY: test
 test:
-	go test -race -count=1 `go list ./...`
+	go test -race -count=1 -coverprofile=coverage.out `go list ./...`
 
 .PHONY: image
 image:

--- a/pkg/services/repo_service_test.go
+++ b/pkg/services/repo_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -150,6 +151,9 @@ func TestGetApps(t *testing.T) {
 			if cc.expectedError != nil {
 				assert.EqualError(t, err, cc.expectedError.Error())
 			} else {
+				sort.Strings(got)
+				sort.Strings(cc.expected)
+
 				assert.Equal(t, got, cc.expected)
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
This PR:
- Adds a GitHub action to the workflow that runs the build (both docker and standalone), and then runs `go test` (the job/steps  are [based on Argo CD's](https://github.com/argoproj/argo-cd/blob/master/.github/workflows/ci-build.yaml))
- Fixes the `TestGetApps` test, which was intermittently failing due to string ordering

Failing test:
```
2020/11/24 12:08:52 proto: tag has too few fields: "-"
--- FAIL: TestGetApps (0.00s)
    --- FAIL: TestGetApps/Happy_Flow (0.00s)
        repo_service_test.go:156: 
            	Error Trace:	repo_service_test.go:156
            	Error:      	Not equal: 
            	            	expected: []string{"app2", "app1"}
            	            	actual  : []string{"app1", "app2"}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,4 +1,4 @@
            	            	 ([]string) (len=2) {
            	            	- (string) (len=4) "app2",
            	            	- (string) (len=4) "app1"
            	            	+ (string) (len=4) "app1",
            	            	+ (string) (len=4) "app2"
            	            	 }
            	Test:       	TestGetApps/Happy_Flow
FAIL
```
