### PR TITLE
Expand on existing developer docs: how to setup dev env and how to run ApplicationSet controller on local machine (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,6 @@ compatibility are made, at least until merging into Argo CD proper.
 ## Proposal:
 * https://docs.google.com/document/d/1juWGr20FQaJmuuTIS8mBFmWWDU422M_FQMuhp5c1jt4/edit?usp=sharing
 
-## Development Instructions
-
-The following assumes you have: 
-
- 1. Installed a recent version of [kustomize](https://github.com/kubernetes-sigs/kustomize) (3.x+). 
- 1. Created a container repository for your development image.
- 1. Deployed ArgoCD into the "argocd" namespace.
- 
-To build and push a container with your current code, and deploy Kubernetes manifests for the controller Deployment:
-
-```bash
-IMAGE="username/argocd-applicationset:v0.0.1" make image deploy
-```
-
-The ApplicationSet controller should now be running in the "argocd" namespace.
-
 ## Example Spec:
 
 ```yaml
@@ -56,4 +40,72 @@ spec:
 ```
 
 Additional examples are available in the [examples](./examples) directory.
+
+
+## Development
+
+### Running the ApplicationSet controller as an image within Kubernetes
+
+The following assumes you have: 
+1. Installed a recent version of [kustomize](https://github.com/kubernetes-sigs/kustomize) (3.x+). 
+2. Created a container repository for your development image.
+  - For example, by creating a repository "(your username)/argocd-applicationset" using [Docker Hub](https://hub.docker.com/) or [Red Hat Quay.io](https://quay.io/).
+3. Ran `docker login` from the CLI, and provided your registry credentials.
+4. Deployed ArgoCD into the `argocd` namespace.
+  - To install Argo CD, follow the [Argo CD Getting Started](https://argoproj.github.io/argo-cd/getting_started/) guide.
+
+To build and push a container with your current code, and deploy Kubernetes manifests for the controller Deployment:
+
+```bash
+# Build and push the image to container registry
+IMAGE="(username)/argocd-applicationset:v0.0.1" make image
+
+# Deploy the ApplicationSet controller manifests
+IMAGE="(username)/argocd-applicationset:v0.0.1" make deploy
+```
+
+The ApplicationSet controller should now be running in the `argocd` namespace.
+
+
+### Running the ApplicationSet Controller as a standalone process from the CLI
+
+When developing a Kubernetes controller, it is often easier to run the controller process from your local CLI, rather than requiring a container rebuild and push for new code changes.
+
+1. First, setup a local Argo CD development environment:
+  - Clone the Argo CD source, and setup an Argo CD dev environment:
+    - [Setting up your development environment](https://argoproj.github.io/argo-cd/developer-guide/contributing/#setting-up-your-development-environment)
+    - [Install the must-have requirements](https://argoproj.github.io/argo-cd/developer-guide/contributing/#install-the-must-have-requirements)
+    - [Build your code and run unit tests](https://argoproj.github.io/argo-cd/developer-guide/contributing/#build-your-code-and-run-unit-tests)
+ 
+2. Ensure that port 8081 is exposed in the Argo CD test server container:
+- In the `Makefile` file at the root of the Argo CD repo:
+    - Add the following to [this location in the Makefile](https://github.com/argoproj/argo-cd/blob/27912a08f151fab038ddb804a618ca8cde01d68e/Makefile#L75)
+    - Replace: `-p 4000:4000 \`
+    - With: `-p 4000:4000 -p 8081:8081 \`
+    - This exposes port 8081 (the repo-server listen port), which is required for ApplicationSet Git generator functionality.
+
+3. Ensure that Argo CD is running
+- Ensure your active namespace is set to `argocd` (for example, `kubectl config view --minify | grep namespace:`).
+- Run `make start` under the Argo CD dev environment.
+- Wait for the Argo CD processes to start within the container.
+- This process should remaining running, alongside the local ApplicationSet controller, during the following steps.
+- Verify that:
+    - You have exposed port 8081 in the Makefile (as described in prerequisites). `docker ps` should show port 8081 as mapped to an accessible IP.
+
+4. Apply the ApplicationSet CRDs into the `argocd` namespace, and build the controller:
+```
+kubectl apply -f manifests/crds/argoproj.io_applicationsets.yaml
+make build
+```
+
+5. Run the Application Set Controller from the CLI:
+```
+NAMESPACE=argocd ./dist/argocd-applicationset --metrics-addr=":18081" --probe-addr=":18082"
+```
+
+On success, you should see (amongst other text):
+```
+INFO	controller-runtime.controller	Starting Controller	{"controller": "applicationset"}
+INFO	controller-runtime.controller	Starting workers	{"controller": "applicationset", "worker count": 1}
+```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The ApplicationSet controller should now be running in the `argocd` namespace.
 
 ### Running the ApplicationSet Controller as a standalone process from the CLI
 
-When developing a Kubernetes controller, it is often easier to run the controller process from your local CLI, rather than requiring a container rebuild and push for new code changes.
+When iteratively developing a Kubernetes controller, it is often easier to run the controller process from your local CLI, rather than requiring a container rebuild and push for new code changes.
 
 1. First, setup a local Argo CD development environment:
   - Clone the Argo CD source, and setup an Argo CD dev environment:
@@ -84,11 +84,11 @@ When developing a Kubernetes controller, it is often easier to run the controlle
     - With: `-p 4000:4000 -p 8081:8081 \`
     - This exposes port 8081 (the repo-server listen port), which is required for ApplicationSet Git generator functionality.
 
-3. Ensure that Argo CD is running
+3. Start Argo CD and wait for startup completion:
 - Ensure your active namespace is set to `argocd` (for example, `kubectl config view --minify | grep namespace:`).
 - Run `make start` under the Argo CD dev environment.
 - Wait for the Argo CD processes to start within the container.
-- This process should remaining running, alongside the local ApplicationSet controller, during the following steps.
+- These processes should remaining running, alongside the local ApplicationSet controller, during the following steps.
 - Verify that:
     - You have exposed port 8081 in the Makefile (as described in prerequisites). `docker ps` should show port 8081 as mapped to an accessible IP.
 
@@ -103,9 +103,8 @@ make build
 NAMESPACE=argocd ./dist/argocd-applicationset --metrics-addr=":18081" --probe-addr=":18082"
 ```
 
-On success, you should see (amongst other text):
+On success, you should see the following(amongst other text):
 ```
 INFO	controller-runtime.controller	Starting Controller	{"controller": "applicationset"}
 INFO	controller-runtime.controller	Starting workers	{"controller": "applicationset", "worker count": 1}
 ```
-


### PR DESCRIPTION
Add developer-focused docs to the project root README.md.

See parent issue for details: https://github.com/argoproj-labs/applicationset/issues/74