### PR TITLE
Intermittent test failure in 'TestGitGenerateParamsFromFiles/handles_error_during_getting_repo_file_contents'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ manifests:
 	controller-gen paths=./api/... crd:trivialVersions=true output:dir=./manifests/crds/
 	controller-gen object paths=./api/...
 
+.PHONY: lint
 lint:
 	golangci-lint --version
 	GOMAXPROCS=2 golangci-lint run --fix --verbose --timeout 300s

--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path"
+	"sort"
 	"time"
 
 	argoprojiov1alpha1 "github.com/argoproj-labs/applicationset/api/v1alpha1"
@@ -76,20 +77,30 @@ func (g *GitGenerator) generateParamsForGitDirectories(appSetGenerator *argoproj
 }
 
 func (g *GitGenerator) generateParamsForGitFiles(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) ([]map[string]string, error) {
-	allPaths := make(map[string]bool)
+
+	// Get all paths that match the requested path string, removing duplicates
+	allPathsMap := make(map[string]bool)
 	for _, requestedPath := range appSetGenerator.Git.Files {
 		paths, err := g.repos.GetPaths(context.TODO(), appSetGenerator.Git.RepoURL, appSetGenerator.Git.Revision, requestedPath.Path)
 		if err != nil {
 			return nil, err
 		}
 		for _, path := range paths {
-			allPaths[path] = true
+			allPathsMap[path] = true
 		}
 	}
 
-	res := []map[string]string{}
+	// Extract the unduplicated map into a list, and sort by path to ensure a deterministic
+	// processing order in the subsequent step
+	allPaths := []string{}
+	for path := range allPathsMap {
+		allPaths = append(allPaths, path)
+	}
+	sort.Strings(allPaths)
 
-	for path, _ := range allPaths {
+	// Generate params from each path, and return
+	res := []map[string]string{}
+	for _, path := range allPaths {
 		params, err := g.generateParamsFromGitFile(appSetGenerator, path)
 		if err != nil {
 			return nil, err

--- a/pkg/generators/git_test.go
+++ b/pkg/generators/git_test.go
@@ -151,7 +151,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 	}{
 		{
 			name:  "happy flow: create params from git files",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{"**/config.json"}},
+			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoPaths: []string{
 				"cluster-config/production/config.json",
 				"cluster-config/staging/config.json",
@@ -200,7 +200,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:                   "handles error during getting repo paths",
-			files:                  []argoprojiov1alpha1.GitFileGeneratorItem{{"**/config.json"}},
+			files:                  []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoPaths:              []string{},
 			repoFileContents:       map[string][]byte{},
 			repoPathsError:         fmt.Errorf("paths error"),
@@ -210,7 +210,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:  "handles error during getting repo file contents",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{"**/config.json"}},
+			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoPaths: []string{
 				"cluster-config/production/config.json",
 				"cluster-config/staging/config.json",
@@ -271,7 +271,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 				assert.EqualError(t, err, c.expectedError.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, c.expected, got)
+				assert.ElementsMatch(t, c.expected, got)
 			}
 
 			argoCDServiceMock.mock.AssertExpectations(t)


### PR DESCRIPTION
The test failure was due to differing ordering of entries within a map between test runs; the fix is to use `assert.ElementsMatch(...)` as suggested by @mgoodness, plus ensuring a deterministic ordering in the order in which paths are processed by the generator (which end users of the generator should find to be a preferable behaviour).

Parent issue #92 

