### PR TITLE
 Kustomize Argo CD integration (and GitHub E2E test action) should use a fixed Argo CD version

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -142,10 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k3s-version: [v1.19.2]
+        k3s-version: [v1.19.2, v1.16.15]
         # k3s-version: [v1.19.2, v1.18.9, v1.17.11, v1.16.15]
-      # needs:
-      # - build-go
     env:
       GOPATH: /home/runner/go
       ARGOCD_FAKE_IN_CLUSTER: 'true'
@@ -238,8 +236,6 @@ jobs:
         run: |
           set -x
           cd "$GITHUB_WORKSPACE/applicationsets"
-          # TODO: re-enable this, or create a validation that ensures this is updated.
-          # make manifests
           kubectl apply -f manifests/crds/argoproj.io_applicationsets.yaml
           make build
           make start-e2e 2>&1 | tee /tmp/appset-e2e-server.log &

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: argoproj/argo-cd
-          ref: v1.8.1
+          ref: v1.8.4
           # Pin a specific commit to prevent Argo CD regressions from impacting us
       - name: Setup Golang
         uses: actions/setup-go@v1

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -159,8 +159,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: argoproj/argo-cd
+          # Pin a specific commit to prevent Argo CD regressions from impacting us:
+          # This version is verified to match a version consistent with the kustomize install yaml, 
+          # by 'hack/verify-argo-cd-versions.sh'.
+          # BEGIN-ARGO-CD-VERSION
           ref: v1.8.4
-          # Pin a specific commit to prevent Argo CD regressions from impacting us
+          # END-ARGO-CD-VERSION
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:

--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -42,7 +42,10 @@ cd ${SRCROOT}/manifests/namespace-install && ${KUSTOMIZE} build . >> ${TEMPFILE}
 mv ${TEMPFILE} ${SRCROOT}/manifests/install.yaml
 cd ${SRCROOT} && chmod 644 manifests/install.yaml
 
-# Use kustomize to render 'manifests/install-with-argo-cd.yaml'
+# Verify that the 'install-with-argo-cd.yaml' is targetting the expected Argo CD version
+"${SRCROOT}/hack/verify-argo-cd-versions.sh"
+
+# Use kustomize to render 'manifests/install-with-argo-cd.yaml
 echo "${AUTOGENMSG}" > ${TEMPFILE}
 cd ${SRCROOT}/manifests/namespace-install-with-argo-cd && ${KUSTOMIZE} build . >> ${TEMPFILE}
 mv ${TEMPFILE} ${SRCROOT}/manifests/install-with-argo-cd.yaml

--- a/hack/verify-argo-cd-versions.sh
+++ b/hack/verify-argo-cd-versions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# To adopt a new version of Argo CD:
+# 1) Update this value to the GitHub tag of the target 'argoproj/argo-cd' release (example: 'v1.8.4'). 
+# 2) Fix the errors that are reported below (by editing the version string in the file reported in the error)
+TARGET_ARGO_CD_VERSION=v1.8.4
+
+# Extract the Argo CD repository string from ci-build.yaml, which SHOULD contain the target Argo CD version
+VERSION_FROM_CI_BUILD=$( awk '/repository: argoproj\/argo-cd/,/Pin a/' .github/workflows/ci-build.yaml )
+
+if [[ $VERSION_FROM_CI_BUILD != *"$TARGET_ARGO_CD_VERSION"* ]]; then
+    echo
+    echo "ERROR: '.github/workflows/ci-build.yaml' does not target the expected Argo CD version: $TARGET_ARGO_CD_VERSION"
+    echo "- Found: $VERSION_FROM_CI_BUILD"
+    exit 1
+fi
+
+# Extract the argoproj/argo-cd GitHub resource URL, which SHOULD contain the target version
+VERSION_FROM_KUSTOMIZATION_YAML=$( cat manifests/namespace-install-with-argo-cd/kustomization.yaml | grep "argoproj/argo-cd" )
+
+if [[ $VERSION_FROM_KUSTOMIZATION_YAML != *"$TARGET_ARGO_CD_VERSION"* ]]; then
+    echo
+    echo "ERROR: 'manifests/namespace-install-with-argo-cd/kustomization.yaml' does not target the expected Argo CD version: $TARGET_ARGO_CD_VERSION"
+    echo "- Found: $VERSION_FROM_KUSTOMIZATION_YAML"
+    exit 1
+fi

--- a/hack/verify-argo-cd-versions.sh
+++ b/hack/verify-argo-cd-versions.sh
@@ -6,7 +6,7 @@
 TARGET_ARGO_CD_VERSION=v1.8.4
 
 # Extract the Argo CD repository string from ci-build.yaml, which SHOULD contain the target Argo CD version
-VERSION_FROM_CI_BUILD=$( awk '/repository: argoproj\/argo-cd/,/Pin a/' .github/workflows/ci-build.yaml )
+VERSION_FROM_CI_BUILD=$( awk '/BEGIN-ARGO-CD-VERSION/,/END-ARGO-CD-VERSION/' .github/workflows/ci-build.yaml )
 
 if [[ $VERSION_FROM_CI_BUILD != *"$TARGET_ARGO_CD_VERSION"* ]]; then
     echo

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -3968,7 +3968,7 @@ spec:
         - -n
         - /usr/local/bin/argocd-util
         - /shared
-        image: argoproj/argocd:v1.8.3
+        image: argoproj/argocd:v1.8.4
         imagePullPolicy: Always
         name: copyutil
         volumeMounts:
@@ -4070,7 +4070,7 @@ spec:
         - argocd-repo-server
         - --redis
         - argocd-redis:6379
-        image: argoproj/argocd:v1.8.3
+        image: argoproj/argocd:v1.8.4
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
@@ -4149,7 +4149,7 @@ spec:
         - argocd-server
         - --staticassets
         - /shared/app
-        image: argoproj/argocd:v1.8.3
+        image: argoproj/argocd:v1.8.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -4225,7 +4225,7 @@ spec:
         - "20"
         - --operation-processors
         - "10"
-        image: argoproj/argocd:v1.8.3
+        image: argoproj/argocd:v1.8.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/manifests/namespace-install-with-argo-cd/kustomization.yaml
+++ b/manifests/namespace-install-with-argo-cd/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 namespace: argocd
 
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v1.8.4/manifests/install.yaml
   - ../base
   - ../crds


### PR DESCRIPTION
This PR adds a check to manifest generation (via `hack/verify-argo-cd-versions.sh`), which verifies that all locations that reference Argo CD are consistent with a single Argo CD target version. 

This also:
- Updates to latest Argo CD v1.8.4
- Slightly cleans up `ci-build.yaml` and adds a new k3s-version for backwards compatibility testing (since I'm editing the file anyway)

Fixes #118