### PR TITLE
Adopt same base image as Argo CD to fix vulnerability scan issues bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o applicationset-controller main.go
 
-FROM debian:10-slim
+FROM ubuntu:20.10
+
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && \
   apt-get install -y git-all && \
   rm -r /var/lib/apt/lists /var/cache/apt/archives


### PR DESCRIPTION
PR switches from Debian to Ubuntu, following Argo CD which previously made the same switch earlier in the year. See parent issue for additional details.

Fixes #150 