### PR TITLE
Applicationset-controller overloads api-server and have memory leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -39,6 +40,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	"github.com/argoproj/pkg/stats"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -150,6 +152,9 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ApplicationSet")
 		os.Exit(1)
 	}
+
+	stats.StartStatsTicker(10 * time.Minute)
+
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("Starting manager")


### PR DESCRIPTION
Fixes #153 

This was caused by our creating a SettingsManager (SettingsManager in settings.go in Argo CD) with every call of the ClusterGenerator. Since the settings manager contains a client and 2 listers, each instance was opening sockets and multiple goroutines to handle resource caching with the k8s server. The socket and these connections were what were occupying the leaked memory:
```
# From SettingsManager
	clientset  kubernetes.Interface
	secrets    v1listers.SecretLister
	configmaps v1listers.ConfigMapLister
```

The fix is:
- Create a single instance of SettingsManager (which is what Argo CD does), and query that instance on each cluster generator call. 
- I've also added Argo's  stat logger, which outputs the memory usage and # of goroutines every 10 minutes, which should allow us to catch similar issues in the future.
