### PR TITLE
Annotations set in application-set not updating apps

### DIFF
--- a/pkg/controllers/applicationset_controller.go
+++ b/pkg/controllers/applicationset_controller.go
@@ -81,6 +81,11 @@ func (r *ApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Do not attempt to further reconcile the ApplicationSet if it is being deleted.
+	if applicationSetInfo.ObjectMeta.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
 	// Log a warning if there are unrecognized generators
 	checkInvalidGenerators(&applicationSetInfo)
 

--- a/pkg/utils/createOrUpdate.go
+++ b/pkg/utils/createOrUpdate.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -72,26 +71,6 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 		},
 		func(a, b argov1alpha1.ApplicationDestination) bool {
 			return a.Namespace == b.Namespace && a.Name == b.Name && a.Server == b.Server
-		},
-		func(a, b metav1.ObjectMeta) bool {
-			// Only include significant fields in the equality comparison, for object metadata
-			filterFields := func(om metav1.ObjectMeta) *metav1.ObjectMeta {
-				result := metav1.ObjectMeta{
-					Name:        om.Name,
-					Namespace:   om.Namespace,
-					Labels:      om.Labels,
-					Annotations: om.Annotations,
-					Finalizers:  om.Finalizers,
-				}
-				return result.DeepCopy()
-			}
-			res := reflect.DeepEqual(filterFields(a), filterFields(b))
-			return res
-		},
-		func(a, b argov1alpha1.ApplicationSpec) bool {
-			// ApplicationSpec can be compared as is
-			res := reflect.DeepEqual(a, b)
-			return res
 		},
 	)
 

--- a/test/e2e/fixture/applicationsets/expectation.go
+++ b/test/e2e/fixture/applicationsets/expectation.go
@@ -7,6 +7,7 @@ import (
 
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type state = string
@@ -110,7 +111,16 @@ func filterFields(input argov1alpha1.Application) argov1alpha1.Application {
 
 	spec := input.Spec
 
+	metaCopy := input.ObjectMeta.DeepCopy()
+
 	output := argov1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      metaCopy.Labels,
+			Annotations: metaCopy.Annotations,
+			Name:        metaCopy.Name,
+			Namespace:   metaCopy.Namespace,
+			Finalizers:  metaCopy.Finalizers,
+		},
 		Spec: argov1alpha1.ApplicationSpec{
 			Source: argov1alpha1.ApplicationSource{
 				Path:           spec.Source.Path,


### PR DESCRIPTION
Fixes #154

The fix for this bug is the change to `createOrUpdateInCluster` in `pkg/controllers/applicationset_controller.go`, everything else in this PR is test updates to ensure the correctness of the fix (for both unit and E2E tests).

The bug occurred because:
- The mutateFunction of `createOrUpdateInCluster` was not copying metadata fields.
- The call to `c.Get(...)` in `CreateOrUpdate(...)` in `createOrUpdate.go` was not replacing the existing fields of the Application parameter that was passed in, causing the objects to appear equal (when they were not). Fix is to pass in a preinitialized `argov1alpha1.Application{}` value into `utils.CreateOrUpdate(...)`. (It's unclear whether this is only an issue with the fakeclient, or a general problem, but in any case this is the fix.)
