### PR TITLE
Git helpers missing from image

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Regenerate the manifests, git diff should report no changes.
         run: |
-          make manifests
+          # Use a fixed version of kustomize, rather than the version on the 'runs-on' image
+          wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.9.4/kustomize_v3.9.4_linux_amd64.tar.gz
+          tar xzf kustomize_v3.9.4_linux_amd64.tar.gz
+          KUSTOMIZE=~/kustomize make manifests
           git diff --exit-code -- .
 
   build-go:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -47,7 +47,7 @@ jobs:
           # Use a fixed version of kustomize, rather than the version on the 'runs-on' image
           wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.9.4/kustomize_v3.9.4_linux_amd64.tar.gz
           tar xzf kustomize_v3.9.4_linux_amd64.tar.gz
-          KUSTOMIZE=~/kustomize make manifests
+          KUSTOMIZE=${PWD}/kustomize make manifests
           git diff --exit-code -- .
 
   build-go:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN go mod download
 COPY main.go .
 COPY api/ api/
 COPY pkg/ pkg/
-
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o applicationset-controller main.go
 
@@ -22,8 +21,14 @@ FROM ubuntu:20.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && \
-  apt-get install -y git-all && \
+  apt-get install -y git-all gpg && \
   rm -r /var/lib/apt/lists /var/cache/apt/archives
+
+# Add Argo CD helper scripts that are required by 'github.com/argoproj/argo-cd/util/git' package
+COPY hack/from-argo-cd/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
+COPY hack/from-argo-cd/gpg-wrapper.sh /usr/local/bin/gpg-wrapper.sh
+COPY hack/from-argo-cd/git-verify-wrapper.sh /usr/local/bin/git-verify-wrapper.sh
+
 
 WORKDIR /
 COPY --from=builder /workspace/applicationset-controller /usr/local/bin/

--- a/hack/from-argo-cd/git-ask-pass.sh
+++ b/hack/from-argo-cd/git-ask-pass.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This script is used as the command supplied to GIT_ASKPASS as a way to supply username/password
+# credentials to git, without having to use git credentials helpers, or having on-disk config.
+case "$1" in
+Username*) echo "${GIT_USERNAME}" ;;
+Password*) echo "${GIT_PASSWORD}" ;;
+esac

--- a/hack/from-argo-cd/git-verify-wrapper.sh
+++ b/hack/from-argo-cd/git-verify-wrapper.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Wrapper script to perform GPG signature validation on git commit SHAs and
+# annotated tags.
+#
+# We capture stderr to stdout, so we can have the output in the logs. Also,
+# we ignore error codes that are emitted if signature verification failed.
+#
+if test "$1" = ""; then
+	echo "Wrong usage of git-verify-wrapper.sh" >&2
+	exit 1
+fi
+
+REVISION="$1"
+TYPE=
+
+# Figure out we have an annotated tag or a commit SHA
+if git describe --exact-match "${REVISION}" >/dev/null 2>&1; then
+	IFS=''
+	TYPE=tag
+	OUTPUT=$(git verify-tag "$REVISION" 2>&1)
+	RET=$?
+else
+	IFS=''
+	TYPE=commit
+	OUTPUT=$(git verify-commit "$REVISION" 2>&1)
+	RET=$?
+fi
+
+case "$RET" in
+0)
+	echo "$OUTPUT"
+	;;
+1)
+	# git verify-tag emits error messages if no signature is found on tag,
+	# which we don't want in the output.
+	if test "$TYPE" = "tag" -a "${OUTPUT%%:*}" = "error"; then
+		OUTPUT=""
+	fi
+	echo "$OUTPUT"
+	RET=0
+	;;
+*)
+	echo "$OUTPUT" >&2
+	;;
+esac
+exit $RET

--- a/hack/from-argo-cd/gpg-wrapper.sh
+++ b/hack/from-argo-cd/gpg-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Simple wrapper around gpg to prevent exit code != 0
+ARGS=$*
+OUTPUT=$(gpg $ARGS 2>&1)
+IFS=''
+RET=$?
+case "$RET" in
+0)
+	echo $OUTPUT
+	;;
+1)
+	echo $OUTPUT
+	RET=0
+	;;
+*)
+	echo $OUTPUT >&2
+	;;
+esac
+exit $RET


### PR DESCRIPTION
As reported on the parent issue, the `.sh` files that Argo CD uses for its git CLI calls are missing from the ApplicationSet image.  This causes a blocking `Username for 'https://github.com':` message from the controller.

Fix is to add those `.sh` files in the appropriate spot within the image.

(I also had to tweak the `.github/workflows/ci-build.yaml` because kustomize version in the GitHub runner was upgraded recently, and we should have been using a fixed version to begin with.)

Fixes #160 