### PR TITLE
ApplicationSet does not support private repos configured using SSH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,16 @@ COPY hack/from-argo-cd/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 COPY hack/from-argo-cd/gpg-wrapper.sh /usr/local/bin/gpg-wrapper.sh
 COPY hack/from-argo-cd/git-verify-wrapper.sh /usr/local/bin/git-verify-wrapper.sh
 
+# Support for mounting configuration from a configmap
+RUN mkdir -p /app/config/ssh && \
+    touch /app/config/ssh/ssh_known_hosts && \
+    ln -s /app/config/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
+
+RUN mkdir -p /app/config/tls
+RUN mkdir -p /app/config/gpg/source && \
+    mkdir -p /app/config/gpg/keys
+#    chown argocd /app/config/gpg/keys && \
+#    chmod 0700 /app/config/gpg/keys
 
 WORKDIR /
 COPY --from=builder /workspace/applicationset-controller /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary
-FROM golang:1.14.12 as builder
+FROM golang:1.16.2 as builder
 
 WORKDIR /workspace
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -26,4 +26,25 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - mountPath: /app/config/ssh
+            name: ssh-known-hosts
+          - mountPath: /app/config/tls
+            name: tls-certs
+          - mountPath: /app/config/gpg/source
+            name: gpg-keys
+          - mountPath: /app/config/gpg/keys
+            name: gpg-keyring
       serviceAccountName: argocd-applicationset-controller
+      volumes:
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -3975,7 +3975,28 @@ spec:
         image: argoprojlabs/argocd-applicationset:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
+        volumeMounts:
+        - mountPath: /app/config/ssh
+          name: ssh-known-hosts
+        - mountPath: /app/config/tls
+          name: tls-certs
+        - mountPath: /app/config/gpg/source
+          name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       serviceAccountName: argocd-applicationset-controller
+      volumes:
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1539,4 +1539,25 @@ spec:
         image: argoprojlabs/argocd-applicationset:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
+        volumeMounts:
+        - mountPath: /app/config/ssh
+          name: ssh-known-hosts
+        - mountPath: /app/config/tls
+          name: tls-certs
+        - mountPath: /app/config/gpg/source
+          name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       serviceAccountName: argocd-applicationset-controller
+      volumes:
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring


### PR DESCRIPTION
Since we're using the Git client code from Argo CD, we need to make sure that we are mounting the Argo CD SSH/TLS secrets into ApplicationSet controller (which the Git code uses when interfacing with private repos via SSH).

Fixes #163 