### PR TITLE
Correct list generator syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ metadata:
 spec:
   generators:
   - list:
-      items:
+      elements:
       - cluster: engineering-dev
         url: https://1.2.3.4
       - cluster: engineering-prod


### PR DESCRIPTION
The list generator calls them "elements" rather than "items"