### PR TITLE
Use a fixed version of Kustomize in the Makefile to generate manifests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,10 +44,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Regenerate the manifests, git diff should report no changes.
         run: |
-          # Use a fixed version of kustomize, rather than the version on the 'runs-on' image
-          wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.9.4/kustomize_v3.9.4_linux_amd64.tar.gz
-          tar xzf kustomize_v3.9.4_linux_amd64.tar.gz
-          KUSTOMIZE=${PWD}/kustomize make manifests
+          make manifests
           git diff --exit-code -- .
 
   build-go:


### PR DESCRIPTION

Fixes #206

See parent issue for details.

Makefiles generated by kubebuilder/operator-sdk include a section of that automatically downloads a specific `kustomize` version. Here I've borrowed that section and hooked it into our Makefile's logic.
