### PR TITLE
Intermittent E2E test failure on TestSimpleGitFilesPreserveResourcesOnDeletion

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -169,6 +169,10 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: '1.14.12'
+      # Add same workaround for port 8084 as argoproj/argo-cd #5658
+      - name: GH actions workaround - Kill XSP4 process
+        run: |
+          sudo pkill mono || true
       - name: Install K3S
         env:
           INSTALL_K3S_VERSION: ${{ matrix.k3s-version }}+k3s1
@@ -215,9 +219,6 @@ jobs:
         timeout-minutes: 30
         run: |
           set -x
-          # Add 8081 as an exposed port to Argo CD test container, to allow us to access repo server for git generators
-          # (this should be upstreamed, to prevent it from breaking here)
-          sed -i 's/4000:4000/4000:4000 -p 8081:8081/' Makefile
           # Something is weird in GH runners -- there's a phantom listener for
           # port 8080 which is not visible in netstat -tulpen, but still there
           # with a HTTP listener. We have API server listening on port 8088
@@ -243,6 +244,8 @@ jobs:
           kubectl apply -f manifests/crds/argoproj.io_applicationsets.yaml
           make build
           make start-e2e 2>&1 | tee /tmp/appset-e2e-server.log &
+          # Uncomment this to see the Argo CD output alongside test output: 
+          # tail -f /tmp/e2e-server.log &
           make test-e2e
       - name: Upload e2e-server logs
         uses: actions/upload-artifact@v2
@@ -250,3 +253,11 @@ jobs:
           name: appset-e2e-server-k8s${{ matrix.k3s-version }}.log
           path: /tmp/appset-e2e-server.log
         if: ${{ failure() }}
+      - name: Upload other Argo CD server log
+        uses: actions/upload-artifact@v2
+        with:
+          name: argocd-e2e-server-k8s${{ matrix.k3s-version }}.log
+          path: /tmp/e2e-server.log
+        if: ${{ failure() }}
+
+        

--- a/docs/Application-Deletion.md
+++ b/docs/Application-Deletion.md
@@ -8,9 +8,10 @@ All `Application` resources created by the ApplicationSet controller (from an Ap
 The end result is that when an ApplicationSet is deleted, the following occurs (in rough order):
 
 - The `ApplicationSet` resource itself is deleted
-- Any `Application` resources that were created from this `ApplicationSet` (as identified by owner reference), will be deleted if `.syncPolicy.preserveResourcesOnDeletion` is set to false
+- Any `Application` resources that were created from this `ApplicationSet` (as identified by owner reference)
 - Any deployed resources (`Deployments`, `Services`, `ConfigMaps`, etc) on the managed cluster, that were created from that `Application` resource (by Argo CD), will be deleted.
     - Argo CD is responsible for handling this deletion, via [the deletion finalizer](https://argoproj.github.io/argo-cd/user-guide/app_deletion/#about-the-deletion-finalizer).
+    - To preserve deployed resources, set `.syncPolicy.preserveResourcesOnDeletion` to true in the ApplicationSet.
 
 Thus the lifecycle of the `ApplicationSet`, the `Application`, and the `Application`'s resources, are equivalent.
 
@@ -20,4 +21,6 @@ kubectl delete ApplicationSet (NAME) --cascade=false
 ```
 
 !!! warning
-    Even if using a non-cascaded delete, the `resources-finalizer.argocd.argoproj.io` is still specified on the `Application`. Thus, when the `Application` is deleted, all of its deployed resources will also be deleted. (The lifecycle of the Application, and its *child* objects, are still equivalent)
+    Even if using a non-cascaded delete, the `resources-finalizer.argocd.argoproj.io` is still specified on the `Application`. Thus, when the `Application` is deleted, all of its deployed resources will also be deleted. (The lifecycle of the Application, and its *child* objects, are still equivalent.)
+
+    To prevent the deletion of the resources of the Application, such as Services, Deployments, etc, set `.syncPolicy.preserveResourcesOnDeletion` to true in the ApplicationSet. This syncPolicy parameter prevents the finalizer from being added to the Application.

--- a/test/e2e/applicationset/applicationset_test.go
+++ b/test/e2e/applicationset/applicationset_test.go
@@ -1,12 +1,15 @@
 package applicationsets
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/argoproj-labs/applicationset/api/v1alpha1"
 	. "github.com/argoproj-labs/applicationset/test/e2e/fixture/applicationsets"
 	"github.com/argoproj-labs/applicationset/test/e2e/fixture/applicationsets/utils"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -313,41 +316,9 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 
 func TestSimpleGitFilesPreserveResourcesOnDeletion(t *testing.T) {
 
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Application",
-				APIVersion: "argoproj.io/v1alpha1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: utils.ArgoCDNamespace,
-			},
-			Spec: argov1alpha1.ApplicationSpec{
-				Project: "default",
-				Source: argov1alpha1.ApplicationSource{
-					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
-					TargetRevision: "HEAD",
-					Path:           "guestbook",
-				},
-				Destination: argov1alpha1.ApplicationDestination{
-					Server:    "https://kubernetes.default.svc",
-					Namespace: "guestbook",
-				},
-			},
-		}
-	}
-
-	expectedApps := []argov1alpha1.Application{
-		generateExpectedApp("engineering-dev-guestbook"),
-		generateExpectedApp("engineering-prod-guestbook"),
-	}
-
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
-
 	Given(t).
 		When().
+		CreateNamespace().
 		// Create a GitGenerator-based ApplicationSet
 		Create(v1alpha1.ApplicationSet{ObjectMeta: metav1.ObjectMeta{
 			Name: "simple-git-generator",
@@ -364,7 +335,12 @@ func TestSimpleGitFilesPreserveResourcesOnDeletion(t *testing.T) {
 						},
 						Destination: argov1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
-							Namespace: "guestbook",
+							Namespace: utils.ApplicationSetNamespace,
+						},
+
+						// Automatically create resources
+						SyncPolicy: &argov1alpha1.SyncPolicy{
+							Automated: &argov1alpha1.SyncPolicyAutomated{},
 						},
 					},
 				},
@@ -384,37 +360,16 @@ func TestSimpleGitFilesPreserveResourcesOnDeletion(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist(expectedApps)).
-
-		// Update the ApplicationSet template namespace, and verify it updates the Applications
+		}).Then().Expect(Pod(func(p corev1.Pod) bool { return strings.Contains(p.Name, "guestbook-ui") })).
 		When().
+		Delete().
 		And(func() {
-			for _, expectedApp := range expectedApps {
-				newExpectedApp := expectedApp.DeepCopy()
-				newExpectedApp.Spec.Destination.Namespace = "guestbook2"
-				expectedAppsNewNamespace = append(expectedAppsNewNamespace, *newExpectedApp)
-			}
-		}).
-		Update(func(appset *v1alpha1.ApplicationSet) {
-			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist(expectedAppsNewNamespace)).
+			t.Log("Waiting 30 seconds to give the cluster a chance to delete the pods.")
+			// Wait 30 seconds to give the cluster a chance to deletes the pods, if it is going to do so.
+			// It should NOT delete the pods; to do so would be an ApplicationSet bug, and
+			// that is what we are testing here.
+			time.Sleep(30 * time.Second)
+			// The pod should continue to exist after 30 seconds.
+		}).Then().Expect(Pod(func(p corev1.Pod) bool { return strings.Contains(p.Name, "guestbook-ui") }))
 
-		// Update the metadata fields in the appset template, and make sure it propagates to the apps
-		When().
-		And(func() {
-			for _, expectedApp := range expectedAppsNewNamespace {
-				expectedAppNewMetadata := expectedApp.DeepCopy()
-				expectedAppNewMetadata.ObjectMeta.Annotations = map[string]string{"annotation-key": "annotation-value"}
-				expectedAppNewMetadata.ObjectMeta.Labels = map[string]string{"label-key": "label-value"}
-				expectedAppsNewMetadata = append(expectedAppsNewMetadata, *expectedAppNewMetadata)
-			}
-		}).
-		Update(func(appset *v1alpha1.ApplicationSet) {
-			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
-			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist(expectedAppsNewMetadata)).
-
-		// Delete the ApplicationSet, and verify it does not delete the Applications
-		When().
-		Delete().Then().Expect(ApplicationsExist(expectedAppsNewMetadata))
 }

--- a/test/e2e/applicationset/applicationset_test.go
+++ b/test/e2e/applicationset/applicationset_test.go
@@ -360,7 +360,8 @@ func TestSimpleGitFilesPreserveResourcesOnDeletion(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(Pod(func(p corev1.Pod) bool { return strings.Contains(p.Name, "guestbook-ui") })).
+			// We use an extra-long duration here, as we might need to wait for image pull.
+		}).Then().ExpectWithDuration(Pod(func(p corev1.Pod) bool { return strings.Contains(p.Name, "guestbook-ui") }), 6*time.Minute).
 		When().
 		Delete().
 		And(func() {

--- a/test/e2e/fixture/applicationsets/actions.go
+++ b/test/e2e/fixture/applicationsets/actions.go
@@ -89,6 +89,23 @@ func (a *Actions) DeleteClusterSecret(secretName string) *Actions {
 	return a
 }
 
+// Create a temporary namespace, from utils.ApplicationSet, for use by the test.
+// This namespace will be deleted on subsequent tests.
+func (a *Actions) CreateNamespace() *Actions {
+	a.context.t.Helper()
+
+	fixtureClient := utils.GetE2EFixtureK8sClient()
+
+	_, err := fixtureClient.KubeClientset.CoreV1().Namespaces().Create(context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.ApplicationSetNamespace}}, metav1.CreateOptions{})
+
+	a.describeAction = fmt.Sprintf("creating namespace '%s'", utils.ApplicationSetNamespace)
+	a.lastOutput, a.lastError = "", err
+	a.verifyAction()
+
+	return a
+}
+
 // Create creates an ApplicationSet using the provided value
 func (a *Actions) Create(appSet v1alpha1.ApplicationSet) *Actions {
 	a.context.t.Helper()

--- a/test/e2e/fixture/applicationsets/consequences.go
+++ b/test/e2e/fixture/applicationsets/consequences.go
@@ -18,11 +18,15 @@ type Consequences struct {
 }
 
 func (c *Consequences) Expect(e Expectation) *Consequences {
+	return c.ExpectWithDuration(e, time.Duration(30)*time.Second)
+}
+
+func (c *Consequences) ExpectWithDuration(e Expectation, timeout time.Duration) *Consequences {
+
 	// this invocation makes sure this func is not reported as the cause of the failure - we are a "test helper"
 	c.context.t.Helper()
 	var message string
 	var state state
-	timeout := time.Duration(60) * time.Second
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
 		state, message = e(c)
 		switch state {

--- a/test/e2e/fixture/applicationsets/consequences.go
+++ b/test/e2e/fixture/applicationsets/consequences.go
@@ -22,7 +22,7 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 	c.context.t.Helper()
 	var message string
 	var state state
-	timeout := time.Duration(30) * time.Second
+	timeout := time.Duration(60) * time.Second
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
 		state, message = e(c)
 		switch state {


### PR DESCRIPTION
This PR:
- Updates the documentation to correctly describe the expected behaviour
- Shortens the test case so that it tests just what is required
- Ensures that, after delete, the test case is testing that for the presence of a Pod, rather than the Application itself.
- Some additional E2E test tweaks to improve reliability.

Fixes #227 