### PR TITLE
fix: handle conversion to string in git generator

### DIFF
--- a/pkg/generators/git.go
+++ b/pkg/generators/git.go
@@ -165,7 +165,7 @@ func (g *GitGenerator) generateParamsFromGitFile(appSetGenerator *argoprojiov1al
 		}
 		params := map[string]string{}
 		for k, v := range flat {
-			params[k] = v.(string)
+			params[k] = fmt.Sprintf("%v", v)
 		}
 		res = append(res, params)
 	}

--- a/pkg/generators/git_test.go
+++ b/pkg/generators/git_test.go
@@ -216,7 +216,8 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
        "key2_2": {
            "key2_2_1": "val2_2_1"
        }
-   }
+   },
+   "key3": 123
 }`),
 				"cluster-config/staging/config.json": []byte(`{
    "cluster": {
@@ -236,6 +237,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 					"key1":                 "val1",
 					"key2.key2_1":          "val2_1",
 					"key2.key2_2.key2_2_1": "val2_2_1",
+					"key3":                 "123",
 				},
 				{
 					"cluster.owner":   "foo.bar@example.com",


### PR DESCRIPTION
Use `fmt.Sprintf` instead of type assertion for converting the incoming parameter to string.

Fixes: #192 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>