### PR TITLE
fix: sanitize cluster name param by replacing unsupported character

### DIFF
--- a/pkg/generators/cluster_test.go
+++ b/pkg/generators/cluster_test.go
@@ -241,3 +241,13 @@ func TestGenerateParams(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeClusterName(t *testing.T) {
+	t.Run("valid DNS-1123 subdomain name", func(t *testing.T) {
+		assert.Equal(t, "cluster-name", sanitizeName("cluster-name"))
+	})
+	t.Run("invalid DNS-1123 subdomain name", func(t *testing.T) {
+		invalidName := "-.--CLUSTER/name  -./.-"
+		assert.Equal(t, "cluster-name", sanitizeName(invalidName))
+	})
+}


### PR DESCRIPTION
Sanitize the cluster name in accordance with the below rules
1. contain no more than 253 characters
2. contain only lowercase alphanumeric characters, '-' or '.'
3. start and end with an alphanumeric character

Closes: #166 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>