### PR TITLE
Update build scripts to target 'argoproj/applicationset' on quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 VERSION?=$(shell cat VERSION)
-IMAGE_NAMESPACE?=argoprojlabs
+IMAGE_NAMESPACE?=argoproj
 IMAGE_NAME?=argocd-applicationset
 IMAGE_TAG?=latest
-CONTAINER_REGISTRY?=
+CONTAINER_REGISTRY?=quay.io
 
 MKDOCS_DOCKER_IMAGE?=squidfunk/mkdocs-material:4.1.1
 MKDOCS_RUN_ARGS?=
@@ -57,7 +57,7 @@ deploy: kustomize manifests
 .PHONY: manifests
 manifests: kustomize generate
 	$(CONTROLLER_GEN) crd:crdVersions=v1 paths="./..." output:crd:artifacts:config=./manifests/crds/
-	KUSTOMIZE=${KUSTOMIZE} hack/generate-manifests.sh
+	KUSTOMIZE=${KUSTOMIZE} CONTAINER_REGISTRY=${CONTAINER_REGISTRY} hack/generate-manifests.sh
 
 .PHONY: lint
 lint:

--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -18,7 +18,7 @@ if [ "$CONTAINER_REGISTRY" != "" ]; then
 fi
 
 IMAGE_NAME="${IMAGE_NAME:-argocd-applicationset}"
-IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-argoprojlabs}"
+IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-argoproj}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 
 # if the tag has not been declared, and we are on a release branch, use the VERSION file.
@@ -34,7 +34,7 @@ if [ "$IMAGE_TAG" = "" ]; then
   IMAGE_TAG=latest
 fi
 
-cd ${SRCROOT}/manifests/base && ${KUSTOMIZE} edit set image argoprojlabs/argocd-applicationset=${CONTAINER_REGISTRY}${IMAGE_NAMESPACE}/$IMAGE_NAME:${IMAGE_TAG}
+cd ${SRCROOT}/manifests/base && ${KUSTOMIZE} edit set image quay.io/argoproj/argocd-applicationset=${CONTAINER_REGISTRY}${IMAGE_NAMESPACE}/$IMAGE_NAME:${IMAGE_TAG}
 
 # Use kustomize to render 'manifests/install.yaml'
 echo "${AUTOGENMSG}" > ${TEMPFILE}

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - command:
             - applicationset-controller
-          image: argoprojlabs/argocd-applicationset:latest
+          image: quay.io/argoproj/argocd-applicationset:latest
           imagePullPolicy: Always
           name: argocd-applicationset-controller
           env:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-- name: argoprojlabs/argocd-applicationset
-  newName: argoprojlabs/argocd-applicationset
+- name: quay.io/argoproj/argocd-applicationset
+  newName: quay.io/argoproj/argocd-applicationset
   newTag: latest
 
 namespace: argocd

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -4444,7 +4444,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: argoprojlabs/argocd-applicationset:latest
+        image: quay.io/argoproj/argocd-applicationset:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
         volumeMounts:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1917,7 +1917,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: argoprojlabs/argocd-applicationset:latest
+        image: quay.io/argoproj/argocd-applicationset:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
         volumeMounts:


### PR DESCRIPTION
This PR switches from Docker Hub to quay.io for official image location, and argoproj as the organization: https://quay.io/repository/argoproj/argocd-applicationset

Fixes #234 