### PR TITLE
TestGetFileContent test is failing when running go test, on Mac

### DIFF
--- a/pkg/services/repo_service_test.go
+++ b/pkg/services/repo_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -319,7 +320,7 @@ func TestGetFileContent(t *testing.T) {
 			repoURL:       "https://github.com/argoproj/argocd-example-apps/",
 			revision:      commitID,
 			path:          "/this-file-does-not-exist.md",
-			expectedError: errors.New("open /tmp/https:__github.com_argoproj_argocd-example-apps_/this-file-does-not-exist.md: no such file or directory"),
+			expectedError: errors.New("open " + os.TempDir() + "/https:__github.com_argoproj_argocd-example-apps_/this-file-does-not-exist.md: no such file or directory"),
 		},
 	}
 


### PR DESCRIPTION
This PR:
- fixes the failing test: Mac OSX doesn't use `/tmp` as its temporary directory (unlike Linux), so the test was failing when run outside the container. This switches to using the system temporary directory from Go.

Fixes #245 