### PR TITLE
docs: use image-push target to build and push an image

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -15,7 +15,7 @@ To build and push a container with your current code, and deploy Kubernetes mani
 
 ```bash
 # Build and push the image to container registry
-IMAGE="(username)/argocd-applicationset:v0.0.1" make image
+IMAGE="(username)/argocd-applicationset:v0.0.1" make image-push
 
 # Deploy the ApplicationSet controller manifests
 IMAGE="(username)/argocd-applicationset:v0.0.1" make deploy


### PR DESCRIPTION
In the development guide it is recommended to use `make image` to build and push an image. `make image-push` would be the right target in this context.