### PR TITLE
Initial commit of labelSelector support for ClusterDecisionResource

### DIFF
--- a/api/v1alpha1/applicationset_types.go
+++ b/api/v1alpha1/applicationset_types.go
@@ -128,9 +128,10 @@ type DuckTypeGenerator struct {
 	//              this includes apiVersion(group/version), kind, matchKey and validation settings
 	// Name is the resource name of the kind, group and version, defined in the ConfigMapRef
 	// RequeueAfterSeconds is how long before the duckType will be rechecked for a change
-	ConfigMapRef        string `json:"configMapRef"`
-	Name                string `json:"name"`
-	RequeueAfterSeconds *int64 `json:"requeueAfterSeconds,omitempty"`
+	ConfigMapRef        string               `json:"configMapRef"`
+	Name                string               `json:"name,omitempty"`
+	RequeueAfterSeconds *int64               `json:"requeueAfterSeconds,omitempty"`
+	LabelSelector       metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	Template ApplicationSetTemplate `json:"template,omitempty"`
 	// Values contains key/value pairs which are passed directly as parameters to the template

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -304,6 +304,7 @@ func (in *DuckTypeGenerator) DeepCopyInto(out *DuckTypeGenerator) {
 		*out = new(int64)
 		**out = **in
 	}
+	in.LabelSelector.DeepCopyInto(&out.LabelSelector)
 	in.Template.DeepCopyInto(&out.Template)
 	if in.Values != nil {
 		in, out := &in.Values, &out.Values

--- a/docs/Generators.md
+++ b/docs/Generators.md
@@ -610,7 +610,16 @@ spec:
  generators:
  - clusterDecisionResource:
     configMapRef: my-configmap  # ConfigMap with GVK information for the duck type resource
-    name: quak                  # The name of the resource
+    name: quak                  # Choose either "name" of the resource or "labelSelector"
+    labelSelector:
+      matchLabels:              # OPTIONAL
+        duck: spotted
+      matchExpression:          # OPTIONAL
+      - key: duck
+        operator: In
+        values:
+        - "spotted"
+        - "canvasback"                         
     requeueAfterSeconds: 60     # OPTIONAL: Checks for changes every 60sec (default 3min)
  template:
    metadata:

--- a/examples/clusterDecisionResource/README.md
+++ b/examples/clusterDecisionResource/README.md
@@ -37,14 +37,14 @@ data:
 
 # Applying the example
 1. Connect to a cluster with the ApplicationSet controller running
-2. Edit the Role for the ApplicationSet service account, and grant it permission to `get` the `placementdecisions` resources, from apiGroups `cluster.open-cluster-management.io/v1alpha1`
+2. Edit the Role for the ApplicationSet service account, and grant it permission to `list` the `placementdecisions` resources, from apiGroups `cluster.open-cluster-management.io/v1alpha1`
 ```yaml
 - apiGroups:
   - "cluster.open-cluster-management.io/v1alpha1"
   resources:
   - placementdecisions
   verbs:
-  - get
+  - list
 ```
 3. Apply the following controller and associated ManagedCluster CRD's:
 https://github.com/open-cluster-management/placement

--- a/manifests/crds/argoproj.io_applicationsets.yaml
+++ b/manifests/crds/argoproj.io_applicationsets.yaml
@@ -57,6 +57,54 @@ spec:
                             is how long before the duckType will be rechecked for
                             a change
                           type: string
+                        labelSelector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -464,7 +512,6 @@ spec:
                           type: object
                       required:
                       - configMapRef
-                      - name
                       type: object
                     clusters:
                       description: ClusterGenerator defines a generator to match against
@@ -1789,6 +1836,60 @@ spec:
                                       is how long before the duckType will be rechecked
                                       for a change
                                     type: string
+                                  labelSelector:
+                                    description: A label selector is a label query
+                                      over a set of resources. The result of matchLabels
+                                      and matchExpressions are ANDed. An empty label
+                                      selector matches all objects. A null label selector
+                                      matches no objects.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -2229,7 +2330,6 @@ spec:
                                     type: object
                                 required:
                                 - configMapRef
-                                - name
                                 type: object
                               clusters:
                                 description: ClusterGenerator defines a generator

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -1805,6 +1805,36 @@ spec:
                         configMapRef:
                           description: ConfigMapRef is a ConfigMap with the duck type definitions needed to retreive the data              this includes apiVersion(group/version), kind, matchKey and validation settings Name is the resource name of the kind, group and version, defined in the ConfigMapRef RequeueAfterSeconds is how long before the duckType will be rechecked for a change
                           type: string
+                        labelSelector:
+                          description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -2132,7 +2162,6 @@ spec:
                           type: object
                       required:
                       - configMapRef
-                      - name
                       type: object
                     clusters:
                       description: ClusterGenerator defines a generator to match against clusters registered with ArgoCD.
@@ -3188,6 +3217,36 @@ spec:
                                   configMapRef:
                                     description: ConfigMapRef is a ConfigMap with the duck type definitions needed to retreive the data              this includes apiVersion(group/version), kind, matchKey and validation settings Name is the resource name of the kind, group and version, defined in the ConfigMapRef RequeueAfterSeconds is how long before the duckType will be rechecked for a change
                                     type: string
+                                  labelSelector:
+                                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -3515,7 +3574,6 @@ spec:
                                     type: object
                                 required:
                                 - configMapRef
-                                - name
                                 type: object
                               clusters:
                                 description: ClusterGenerator defines a generator to match against clusters registered with ArgoCD.

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -44,6 +44,36 @@ spec:
                         configMapRef:
                           description: ConfigMapRef is a ConfigMap with the duck type definitions needed to retreive the data              this includes apiVersion(group/version), kind, matchKey and validation settings Name is the resource name of the kind, group and version, defined in the ConfigMapRef RequeueAfterSeconds is how long before the duckType will be rechecked for a change
                           type: string
+                        labelSelector:
+                          description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -371,7 +401,6 @@ spec:
                           type: object
                       required:
                       - configMapRef
-                      - name
                       type: object
                     clusters:
                       description: ClusterGenerator defines a generator to match against clusters registered with ArgoCD.
@@ -1427,6 +1456,36 @@ spec:
                                   configMapRef:
                                     description: ConfigMapRef is a ConfigMap with the duck type definitions needed to retreive the data              this includes apiVersion(group/version), kind, matchKey and validation settings Name is the resource name of the kind, group and version, defined in the ConfigMapRef RequeueAfterSeconds is how long before the duckType will be rechecked for a change
                                     type: string
+                                  labelSelector:
+                                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -1754,7 +1813,6 @@ spec:
                                     type: object
                                 required:
                                 - configMapRef
-                                - name
                                 type: object
                               clusters:
                                 description: ClusterGenerator defines a generator to match against clusters registered with ArgoCD.

--- a/pkg/generators/cluster_test.go
+++ b/pkg/generators/cluster_test.go
@@ -232,7 +232,7 @@ func TestGenerateParams(t *testing.T) {
 			}, nil)
 
 			if testCase.expectedError != nil {
-				assert.Error(t, testCase.expectedError, err)
+				assert.EqualError(t, err, testCase.expectedError.Error())
 			} else {
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, testCase.expected, got)

--- a/pkg/generators/duck_type.go
+++ b/pkg/generators/duck_type.go
@@ -165,9 +165,7 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 
 		log.WithField("duckResourceStatus", duckResource.Object["status"]).Debug("found resource")
 
-		for _, decision := range duckResource.Object["status"].(map[string]interface{})[statusListKey].([]interface{}) {
-			clusterDecisions = append(clusterDecisions, decision)
-		}
+		clusterDecisions = append(clusterDecisions, duckResource.Object["status"].(map[string]interface{})[statusListKey].([]interface{})...)
 
 	}
 	log.Infof("Number of decisions found: %v", len(clusterDecisions))
@@ -175,7 +173,7 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 	// Read this outside the loop to improve performance
 	argoClusters := clustersFromArgoCD.Items
 
-	if clusterDecisions != nil && len(clusterDecisions) > 0 {
+	if len(clusterDecisions) > 0 {
 		for _, cluster := range clusterDecisions {
 
 			// generated instance of cluster params


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* This adds labelSelector support to the ClusterDecisionResource generator
* It also fixed an issue in the functional tests showing false positives
* I also fixed cluster_test.go which had the same false positive check
* Includes a documentation update as well to show how a `labelSelector` would be used. (pulls in standard Kubernetes labelSelector)