### PR TITLE
fix: remove unnecessary RBAC permissions

### DIFF
--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -47,11 +47,9 @@ rules:
       - events
     verbs:
       - create
-      - delete
       - get
       - list
       - patch
-      - update
       - watch
   - apiGroups:
       - ''


### PR DESCRIPTION
This PR updates RBAC policies assigned to the applicationset controller so that it does not request unused privileges not available by default at namespace level
 - remove unnecessary RBAC permissions 'delete events' and 'update events'