### PR TITLE
fix: remove unnecessary RBAC permissions

### DIFF
--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -47,11 +47,9 @@ rules:
       - events
     verbs:
       - create
-      - delete
       - get
       - list
       - patch
-      - update
       - watch
   - apiGroups:
       - ''

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -6413,11 +6413,9 @@ rules:
   - events
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - ""

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -4314,11 +4314,9 @@ rules:
   - events
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
This PR updates RBAC policies assigned to the applicationset controller so that it does not request unused privileges not available by default at namespace level
- remove unnecessary RBAC permissions 'delete events' and 'update events'