### PR TITLE
Issue #170 is not solved when using server, only when using name for destination

### DIFF
--- a/pkg/controllers/applicationset_controller.go
+++ b/pkg/controllers/applicationset_controller.go
@@ -445,7 +445,7 @@ func (r *ApplicationSetReconciler) removeFinalizerOnInvalidDestination(ctx conte
 		return nil
 	}
 
-	validDestination := true
+	var validDestination bool
 
 	// Detect if the destination is invalid (name doesn't correspond to a matching cluster)
 	if err := utils.ValidateDestination(ctx, &app.Spec.Destination, r.KubeClientset, applicationSet.Namespace); err != nil {

--- a/pkg/controllers/applicationset_controller.go
+++ b/pkg/controllers/applicationset_controller.go
@@ -383,7 +383,7 @@ func (r *ApplicationSetReconciler) getCurrentApplications(_ context.Context, app
 	return current.Items, nil
 }
 
-// deleteInCluster will delete application that are current in the cluster but not in appList.
+// deleteInCluster will delete Applications that are currently on the cluster, but not in appList.
 // The function must be called after all generators had been called and generated applications
 func (r *ApplicationSetReconciler) deleteInCluster(ctx context.Context, applicationSet argoprojiov1alpha1.ApplicationSet, desiredApplications []argov1alpha1.Application) error {
 

--- a/pkg/controllers/applicationset_controller_test.go
+++ b/pkg/controllers/applicationset_controller_test.go
@@ -1432,9 +1432,10 @@ func TestDeleteInCluster(t *testing.T) {
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
 
 		r := ApplicationSetReconciler{
-			Client:   client,
-			Scheme:   scheme,
-			Recorder: record.NewFakeRecorder(len(initObjs) + len(c.expected)),
+			Client:        client,
+			Scheme:        scheme,
+			Recorder:      record.NewFakeRecorder(len(initObjs) + len(c.expected)),
+			KubeClientset: kubefake.NewSimpleClientset(),
 		}
 
 		err = r.deleteInCluster(context.TODO(), c.appSet, c.desiredApps)

--- a/pkg/utils/clusterUtils.go
+++ b/pkg/utils/clusterUtils.go
@@ -47,7 +47,8 @@ const (
 
 func ListClusters(ctx context.Context, clientset kubernetes.Interface, namespace string) (*appv1.ClusterList, error) {
 
-	clusterSecretsList, err := clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeCluster})
+	clusterSecretsList, err := clientset.CoreV1().Secrets(namespace).List(ctx,
+		metav1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeCluster})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/applicationset/cluster_e2e_test.go
+++ b/test/e2e/applicationset/cluster_e2e_test.go
@@ -303,7 +303,6 @@ func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
 		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2}))
 }
 
-// There is a bug in ArgoCD that prevents this test from passing: https://github.com/argoproj/argo-cd/issues/5817
 func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
 
 	expectedAppTemplate := argov1alpha1.Application{


### PR DESCRIPTION
This is the same fix as I made on Argo CD [here](https://github.com/argoproj/argo-cd/pull/6557) but since we support older Argo CDs in ApplicationSet controller, it needs to be made here as well.
- In addition to verifying using the name field (as before), we now also verify using the server field
- Unit test to verify the logic is correct

Fixes #220 