### PR TITLE
ApplicationSets that initially fail validation might not be re-reconciled

### DIFF
--- a/pkg/services/scm_provider/github_test.go
+++ b/pkg/services/scm_provider/github_test.go
@@ -11,7 +11,9 @@ import (
 
 func checkRateLimit(t *testing.T, err error) {
 	// Check if we've hit a rate limit, don't fail the test if so.
-	if err != nil && strings.Contains(err.Error(), "rate limit exceeded") {
+	if err != nil && (strings.Contains(err.Error(), "rate limit exceeded") ||
+		(strings.Contains(err.Error(), "API rate limit") && strings.Contains(err.Error(), "still exceeded"))) {
+
 		allowRateLimitErrors := os.Getenv("CI") == ""
 		t.Logf("Got a rate limit error, consider setting $GITHUB_TOKEN to increase your GitHub API rate limit: %v\n", err)
 		if allowRateLimitErrors {


### PR DESCRIPTION
This PR:
- Now queues a reconcile on validation error
- Unit test to verify that behaviour
- Tweak to unrelated Git unit test

Fixes https://github.com/argoproj-labs/applicationset/issues/219