### PR TITLE
Provide SHA for latest commit on a branch in variables

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+vendor
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+dist/

--- a/pkg/generators/scm_provider.go
+++ b/pkg/generators/scm_provider.go
@@ -93,6 +93,7 @@ func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 			"repository":   repo.Repository,
 			"url":          repo.URL,
 			"branch":       repo.Branch,
+			"sha":          repo.SHA,
 			"labels":       strings.Join(repo.Labels, ","),
 		})
 	}

--- a/pkg/generators/scm_provider_test.go
+++ b/pkg/generators/scm_provider_test.go
@@ -87,6 +87,7 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 				Repository:   "repo1",
 				URL:          "git@github.com:myorg/repo1.git",
 				Branch:       "main",
+				SHA:          "abcd1234",
 				Labels:       []string{"prod", "staging"},
 			},
 			{
@@ -94,6 +95,7 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 				Repository:   "repo2",
 				URL:          "git@github.com:myorg/repo2.git",
 				Branch:       "main",
+				SHA:          "00000000",
 			},
 		},
 	}
@@ -107,6 +109,7 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 	assert.Equal(t, "repo1", params[0]["repository"])
 	assert.Equal(t, "git@github.com:myorg/repo1.git", params[0]["url"])
 	assert.Equal(t, "main", params[0]["branch"])
+	assert.Equal(t, "abcd1234", params[0]["sha"])
 	assert.Equal(t, "prod,staging", params[0]["labels"])
 	assert.Equal(t, "repo2", params[1]["repository"])
 }

--- a/pkg/services/scm_provider/types.go
+++ b/pkg/services/scm_provider/types.go
@@ -11,6 +11,7 @@ type Repository struct {
 	Repository   string
 	URL          string
 	Branch       string
+	SHA          string
 	Labels       []string
 }
 


### PR DESCRIPTION
This feature adds `sha` to the list of params exposed by the SCMGenerator representing the latest commit.
This allows setting image with the sha tag for continuous deployment.

### TODO:
- [x] github
- [x] gitlab