### PR TITLE
Fix Git Generator Files path example in docs (#407)

### DIFF
--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -223,7 +223,7 @@ As with other generators, clusters *must* already be defined within Argo CD, in 
 
 In addition to the flattened key/value pairs from the configuration file, the following generator parameters are provided:
 
-- `{{path}}`: The path to the matching configuration file within the Git repository. Example: `/cluster-config/staging/config.json`
+- `{{path}}`: The path to the folder containing matching configuration file within the Git repository. Example: `/clusters/clusterA`, if the config file was `/clusters/clusterA/config.json`
 - `{{path.basename}}`: The filename of the configuration file. Example: `config.json`
 
 ## Webhook Configuration


### PR DESCRIPTION
Fix path parameter example in `Generators-Git.md`.

Relates to #407.