### PR TITLE
Corrected wrong info about path and path.basename

### DIFF
--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -224,7 +224,7 @@ As with other generators, clusters *must* already be defined within Argo CD, in 
 In addition to the flattened key/value pairs from the configuration file, the following generator parameters are provided:
 
 - `{{path}}`: The path to the folder containing matching configuration file within the Git repository. Example: `/clusters/clusterA`, if the config file was `/clusters/clusterA/config.json`
-- `{{ path.basename }}`: basename of path to the folder containing the configuration file (eg clusterA)
+- `{{path.basename}}`: basename of path to the folder containing the configuration file (eg clusterA)
 
 ## Webhook Configuration
 

--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -224,7 +224,7 @@ As with other generators, clusters *must* already be defined within Argo CD, in 
 In addition to the flattened key/value pairs from the configuration file, the following generator parameters are provided:
 
 - `{{path}}`: The path to the folder containing matching configuration file within the Git repository. Example: `/clusters/clusterA`, if the config file was `/clusters/clusterA/config.json`
-- `{{path.basename}}`: The filename of the configuration file. Example: `config.json`
+- `{{ path.basename }}`: basename of path to the folder containing the configuration file (eg clusterA)
 
 ## Webhook Configuration
 

--- a/docs/Generators-Git.md
+++ b/docs/Generators-Git.md
@@ -224,7 +224,7 @@ As with other generators, clusters *must* already be defined within Argo CD, in 
 In addition to the flattened key/value pairs from the configuration file, the following generator parameters are provided:
 
 - `{{path}}`: The path to the folder containing matching configuration file within the Git repository. Example: `/clusters/clusterA`, if the config file was `/clusters/clusterA/config.json`
-- `{{path.basename}}`: basename of path to the folder containing the configuration file (eg clusterA)
+- `{{path.basename}}`: Basename of the path to the folder containing the configuration file (e.g. `clusterA`, with the above example.)
 
 ## Webhook Configuration
 


### PR DESCRIPTION
Corrected wrong info in doc about _Git Generator: Files_  fixed #407   by copying documentation from https://github.com/argoproj-labs/applicationset/issues/258#issuecomment-856140869 as suggested in https://github.com/argoproj-labs/applicationset/issues/407#issuecomment-961571470