### PR TITLE
fixes RepoHasPath error handling

### DIFF
--- a/pkg/services/scm_provider/gitlab.go
+++ b/pkg/services/scm_provider/gitlab.go
@@ -95,11 +95,11 @@ func (g *GitlabProvider) RepoHasPath(_ context.Context, repo *Repository, path s
 		Path: &path,
 		Ref:  &repo.Branch,
 	})
-	if resp.TotalItems == 0 {
-		return false, nil
-	}
 	if err != nil {
 		return false, err
+	}
+	if resp.TotalItems == 0 {
+		return false, nil
 	}
 	return true, nil
 }


### PR DESCRIPTION
In the case that gitlab is unreachable , RepoHasPath would return false with NO error , thus filtering out the app from the "desired apps". This is not a wanted behaviour as the check could not be performed correctly.
The fixes checks the error from ListTree first, then checks the results.