### PR TITLE
E2E tests should use application-controller serviceaccount, rather than applicationset-controller serviceaccount

### DIFF
--- a/test/e2e/fixture/applicationsets/consequences.go
+++ b/test/e2e/fixture/applicationsets/consequences.go
@@ -11,7 +11,6 @@ import (
 	"github.com/argoproj/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // this implements the "then" part of given/when/then
@@ -75,7 +74,7 @@ func (c *Consequences) app(name string) *argov1alpha1.Application {
 func (c *Consequences) apps() []argov1alpha1.Application {
 
 	fixtureClient := utils.GetE2EFixtureK8sClient()
-	list, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(utils.ArgoCDNamespace).List(context.Background(), v1.ListOptions{})
+	list, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(utils.ArgoCDNamespace).List(context.Background(), metav1.ListOptions{})
 	errors.CheckError(err)
 
 	if list == nil {

--- a/test/e2e/fixture/applicationsets/expectation.go
+++ b/test/e2e/fixture/applicationsets/expectation.go
@@ -157,9 +157,13 @@ func getDiff(orig, new argov1alpha1.Application) (string, error) {
 
 // getConditionDiff returns a string containing a comparison result of two ApplicationSetCondition (for test output/debug purposes)
 func getConditionDiff(orig, new []v1alpha1.ApplicationSetCondition) (string, error) {
+	if len(orig) != len(new) {
+		return fmt.Sprintf("mismatch between condition sizes: %v %v", len(orig), len(new)), nil
+	}
+
 	var bytes []byte
 
-	for index, _ := range orig {
+	for index := range orig {
 		b, _, err := diff.CreateTwoWayMergePatch(orig[index], new[index], orig[index])
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This PR looks for a service account named `*application-controller*`, and uses that to create an Argo CD cluster secret for the cluster creation tests. Previously it used `applicationset-controller`, but that didn't work because that serviceaccount is too unprivileged.

Fixes #432
