### PR TITLE
chore: set applicationset-controller containerPort name

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           name: argocd-applicationset-controller
           ports:
           - containerPort: 7000
+            name: webhook
           env:
             - name: NAMESPACE
               valueFrom:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -12,6 +12,6 @@ spec:
   - name: webhook
     port: 7000
     protocol: TCP
-    targetPort: 7000
+    targetPort: webhook
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -16135,7 +16135,7 @@ spec:
   - name: webhook
     port: 7000
     protocol: TCP
-    targetPort: 7000
+    targetPort: webhook
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -16293,6 +16293,7 @@ spec:
         name: argocd-applicationset-controller
         ports:
         - containerPort: 7000
+          name: webhook
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -13702,7 +13702,7 @@ spec:
   - name: webhook
     port: 7000
     protocol: TCP
-    targetPort: 7000
+    targetPort: webhook
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -13737,6 +13737,7 @@ spec:
         name: argocd-applicationset-controller
         ports:
         - containerPort: 7000
+          name: webhook
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts


### PR DESCRIPTION
Hi,

A small change removes the redundancy of the port number by setting the applicationset-controller containerPort name.

It's better for readability as well as it minimizes the places to touch if the port is changed.

Thanks.