### PR TITLE
feat: make webhook address configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var probeBindAddr string
+	var webhookAddr string
 	var enableLeaderElection bool
 	var namespace string
 	var argocdRepoServer string
@@ -83,6 +84,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeBindAddr, "probe-addr", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&webhookAddr, "webhook-addr", ":7000", "The address the webhook endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -158,7 +160,7 @@ func main() {
 		setupLog.Error(err, "failed to create webhook handler")
 		os.Exit(1)
 	}
-	startWebhookServer(webhookHandler)
+	startWebhookServer(webhookHandler, webhookAddr)
 
 	terminalGenerators := map[string]generators.Generator{
 		"List":                    generators.NewListGenerator(),
@@ -232,12 +234,12 @@ func setLoggingLevel(debug bool, logLevel string) {
 	}
 }
 
-func startWebhookServer(webhookHandler *utils.WebhookHandler) {
+func startWebhookServer(webhookHandler *utils.WebhookHandler, webhookAddr string) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/webhook", webhookHandler.Handler)
 	go func() {
 		setupLog.Info("Starting webhook server")
-		err := http.ListenAndServe(":7000", mux)
+		err := http.ListenAndServe(webhookAddr, mux)
 		if err != nil {
 			setupLog.Error(err, "failed to start webhook server")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -158,9 +158,11 @@ func main() {
 	webhookHandler, err := utils.NewWebhookHandler(namespace, argoSettingsMgr, mgr.GetClient())
 	if err != nil {
 		setupLog.Error(err, "failed to create webhook handler")
-		os.Exit(1)
 	}
-	startWebhookServer(webhookHandler, webhookAddr)
+
+	if webhookHandler != nil {
+		startWebhookServer(webhookHandler, webhookAddr)
+	}
 
 	terminalGenerators := map[string]generators.Generator{
 		"List":                    generators.NewListGenerator(),


### PR DESCRIPTION
Currently, the webhook address is hardcoded to ":7000". This PR introduces the below changes:

1. `--webhook-addr` flag to make the webhook address configurable.

Example:
```shell
./dist/argocd-applicationset --webhook-addr=":9999" --logformat=json
```

2. Remove the hard exit that stops ApplicationSet whenever it fails to create a webhook handler.

ref: https://github.com/argoproj-labs/applicationset/pull/341/files#r779156282