### PR TITLE
fix: reap zombie processes in argocd-applicationset-controller pod using tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM docker.io/library/ubuntu:21.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get dist-upgrade -y && \
-  apt-get install -y git git-lfs gpg && \
+  apt-get install -y git git-lfs gpg tini && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists /var/cache/apt/archives /tmp/* /var/tmp/*
 
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get dist-upgrade -y && \
 COPY hack/from-argo-cd/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 COPY hack/from-argo-cd/gpg-wrapper.sh /usr/local/bin/gpg-wrapper.sh
 COPY hack/from-argo-cd/git-verify-wrapper.sh /usr/local/bin/git-verify-wrapper.sh
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Support for mounting configuration from a configmap
 RUN mkdir -p /app/config/ssh && \

--- a/docs/Controlling-Resource-Modification.md
+++ b/docs/Controlling-Resource-Modification.md
@@ -82,6 +82,7 @@ spec:
     spec:
       containers:
       - command:
+        - entrypoint.sh
         - applicationset-controller
         # Insert new parameters here, for example:
         # --policy create-only

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# If we're started as PID 1, we should wrap command execution through tini to
+# prevent leakage of orphaned processes ("zombies").
+if test "$$" = "1"; then
+	exec tini -- $@
+else
+	exec "$@"
+fi

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - command:
+            - entrypoint.sh
             - applicationset-controller
           image: quay.io/argoproj/argocd-applicationset:latest
           imagePullPolicy: Always

--- a/manifests/install-with-argo-cd.yaml
+++ b/manifests/install-with-argo-cd.yaml
@@ -16305,6 +16305,7 @@ spec:
     spec:
       containers:
       - command:
+        - entrypoint.sh
         - applicationset-controller
         env:
         - name: NAMESPACE

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -13726,6 +13726,7 @@ spec:
     spec:
       containers:
       - command:
+        - entrypoint.sh
         - applicationset-controller
         env:
         - name: NAMESPACE


### PR DESCRIPTION
Fixes #452 

Inspired by https://github.com/argoproj/argo-cd/pull/3721, tried to use tini to reap zombie processes  

Co-authored-by: Erkan Zileli <erkanzileli@gmail.com>